### PR TITLE
Add supervised cancellation and timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Queue capacity/depth introspection and explicit abort propagation.
 - Support and CI coverage for Ruby 3.3, 3.4, and 4.0.
 - A documented roadmap for supervised pipelines and persistent executors.
+- `CancellationToken` for explicit cancellation shared across connected stages.
+- `Execution` lifecycle state, timing, wait, error, and cancellation introspection.
+- Complete-stage `timeout` and per-batch `worker_timeout` controls on every map variant.
+- Cancellation, lifecycle, and timeout helpers on asynchronous result queues.
 
 ### Changed
 
@@ -17,6 +21,8 @@
 - Thread errors propagate without changing `Thread.abort_on_exception` globally.
 - Fork workers are reaped deterministically and non-marshallable results return a clear error.
 - Queue close operations wake blocked producers and consumers safely.
+- Queue waits now participate in execution cancellation and deadlines without polling.
+- Fork cancellation escalates from `TERM` to `KILL` when a child does not exit promptly.
 - Runtime support now targets maintained Ruby releases, requiring Ruby 3.3 or newer.
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -115,6 +115,60 @@ The final batch may contain fewer than `batch_size` items.
 
 Synchronous transforms buffer their complete result before returning, so their source must report a finite integer size. Use `map_async` or `map_batches_async` for enumerators, open queues, continuous sources, and other unknown-size streams.
 
+## Supervision, cancellation, and timeouts
+
+Every transform has a `Thimble::Execution` with an explicit lifecycle:
+
+```text
+pending -> running -> succeeded
+                   -> failed
+                   -> cancelled
+                   -> timed_out
+```
+
+Asynchronous result queues expose that execution directly and provide convenience methods such as `state`, `wait`, `cancel`, `running?`, `succeeded?`, `cancelled?`, `timed_out?`, and `error`.
+
+```ruby
+result = Thimble::Thimble
+  .new(events, manager)
+  .map_async(timeout: 30, worker_timeout: 5) do |event|
+    client.deliver(event)
+  end
+
+unless result.wait(timeout: 35)
+  result.cancel('caller stopped waiting')
+end
+
+raise result.error if result.failed? || result.timed_out?
+```
+
+The supervision options are available on `map`, `map_async`, `map_batches`, and `map_batches_async`:
+
+| Option | Meaning |
+| --- | --- |
+| `timeout` | Deadline for the complete stage, including source enumeration, worker execution, queue waits, and downstream backpressure |
+| `worker_timeout` | Maximum runtime for one dispatched worker batch |
+| `cancellation` | A shared `Thimble::CancellationToken` used to cancel related stages together |
+
+A shared cancellation token provides pipeline-wide cancellation without global state:
+
+```ruby
+token = Thimble::CancellationToken.new
+
+contents = Thimble::Thimble
+  .new(paths, read_manager)
+  .map_async(cancellation: token) { |path| File.binread(path) }
+
+responses = Thimble::Thimble
+  .new(contents, submit_manager)
+  .map_batches_async(cancellation: token) { |batch| client.submit(batch) }
+
+# From a signal handler coordinator, request handler, or shutdown path:
+token.cancel('service shutdown')
+```
+
+Cancellation and timeout failures abort connected queues, wake blocked producers and consumers, stop active workers, and surface through the asynchronous result queue. Thread-worker blocks that perform long loops can capture the shared token and call token.checkpoint!` for cooperative cancellation. Fork workers cannot observe token changes made after the fork, so the parent terminates and reaps them when cancellation or a timeout occurs.
+
 ## Manager options
 
 | Option | Meaning |
@@ -145,7 +199,7 @@ The two pipelines cannot collectively exceed four active workers.
 
 ## ThimbleQueue
 
-`ThimbleQueue` is a bounded multi-producer, multi-consumer queue:
+`ThimbleQueue is a bounded multi-producer, multi-consumer queue:
 
 ```ruby
 queue = Thimble::ThimbleQueue.new(10, 'records')
@@ -167,8 +221,9 @@ Important semantics:
 
 - Worker exceptions are propagated to synchronous callers.
 - Asynchronous failures abort the result queue and are raised when the result is consumed.
-- A failed stage stops its remaining workers and wakes blocked producers and consumers.
-- Fork workers are explicitly reaped by the parent.
+- A failed, cancelled, or timed-out stage stops its remaining workers and wakes blocked producers and consumers.
+- `Execution#error`, timestamps, duration, and terminal state preserve structured operation context.
+- Fork workers are explicitly reaped by the parent, with `TERM` followed by `KILL` escalation for uncooperative children.
 - Non-marshallable fork results become a descriptive worker error instead of silently hanging.
 
 ## Choosing a worker type

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,16 +9,19 @@ Thimble is being developed as a bounded pipeline runtime rather than a generic r
 - shared concurrency budgets;
 - thread and fork execution;
 - explicit worker failure propagation;
-- deterministic close, abort, and process-reaping behavior.
+- deterministic close, abort, and process-reaping behavior;
+- explicit execution lifecycle states and timing context;
+- shared cooperative cancellation tokens;
+- complete-stage and per-worker timeouts;
+- cancellation propagation through blocked queues and connected stages.
 
-## Next: pipeline supervision
+## Next: complete pipeline supervision
 
-- explicit pipeline lifecycle states;
-- cooperative cancellation tokens;
-- stage and worker timeouts;
-- graceful versus immediate shutdown;
-- retry policies with bounded backoff;
-- structured success and failure context.
+- graceful drain versus immediate cancellation;
+- retry policies with bounded exponential backoff and jitter;
+- structured item, batch, and attempt failure context;
+- configurable retry classification and dead-letter hooks;
+- signal-friendly shutdown orchestration for multiple stages.
 
 ## Next: first-class stages
 

--- a/lib/manager.rb
+++ b/lib/manager.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
 
+require_relative 'supervision'
+
 module Thimble
   class WorkerProcessError < RuntimeError; end
 
-  Worker = Struct.new(:pid, :reader, :result, :error, :done, keyword_init: true)
+  Worker = Struct.new(:pid, :reader, :result, :error, :done, :started_at, :batch_size, keyword_init: true)
   WorkerRegistration = Struct.new(:worker, :id, keyword_init: true)
 
   class Manager
+    PROCESS_TERM_GRACE = 0.25
+    PROCESS_WAIT_INTERVAL = 0.01
+
     attr_reader :max_workers, :batch_size, :queue_size, :worker_type
 
     def initialize(max_workers: 6, batch_size: 1000, queue_size: 1000, worker_type: :fork)
@@ -52,7 +57,8 @@ module Thimble
       end
       return nil unless reservation_active
 
-      worker = get_worker(batch, batch_mode: batch_mode, &block)
+      started_at = monotonic_now
+      worker = get_worker(batch, batch_mode: batch_mode, started_at: started_at, &block)
       @mutex.synchronize do
         @reserved_workers -= 1
         reservation_active = false
@@ -75,6 +81,7 @@ module Thimble
     def sub_worker(worker, id)
       raise 'Worker must contain a pid!' if worker.pid.nil?
 
+      worker.started_at ||= monotonic_now
       @mutex.synchronize do
         @current_workers[worker.pid] = WorkerRegistration.new(worker: worker, id: id)
         @condition.broadcast
@@ -108,36 +115,77 @@ module Thimble
       end
     end
 
-    # Blocks until this pipeline can make progress: one of its workers finishes,
-    # a shared worker slot opens, or it has no remaining workers.
-    def wait_for_change(id, wait_for_capacity: true)
+    def timed_out_workers(id, timeout)
+      return [] unless timeout
+
+      now = monotonic_now
+      @mutex.synchronize do
+        @current_workers.filter_map do |_key, registration|
+          next unless registration.id == id
+
+          worker = registration.worker
+          worker if !worker.done && worker.started_at && now - worker.started_at >= timeout
+        end
+      end
+    end
+
+    def time_until_worker_timeout(id, timeout)
+      return nil unless timeout
+
+      now = monotonic_now
+      @mutex.synchronize do
+        remaining = @current_workers.filter_map do |_key, registration|
+          next unless registration.id == id
+
+          worker = registration.worker
+          next if worker.done || !worker.started_at
+
+          timeout - (now - worker.started_at)
+        end
+        remaining.empty? ? nil : [remaining.min, 0.0].max
+      end
+    end
+
+    # Blocks until this pipeline can make progress or the optional timeout
+    # expires. Callers re-check their execution deadline after every wake-up.
+    def wait_for_change(id, wait_for_capacity: true, timeout: nil)
+      validate_wait_timeout!(timeout)
       return if wait_for_capacity && worker_available?
 
       if @worker_type == :fork
         readers = current_workers(id).values.filter_map do |entry|
           entry.worker.reader unless entry.worker.reader.closed?
         end
-        return IO.select(readers, nil, nil, 0.1) unless readers.empty?
+        unless readers.empty?
+          select_timeout = timeout.nil? ? 0.1 : [timeout, 0.1].min
+          IO.select(readers, nil, nil, select_timeout)
+          return
+        end
       end
 
       @mutex.synchronize do
-        until (wait_for_capacity && worker_available_unlocked?) ||
-              completed_worker_unlocked?(id) ||
-              (!wait_for_capacity && !working_for_unlocked?(id))
-          @condition.wait(@mutex)
-        end
+        return if (wait_for_capacity && worker_available_unlocked?) ||
+                  completed_worker_unlocked?(id) ||
+                  (!wait_for_capacity && !working_for_unlocked?(id))
+
+        @condition.wait(@mutex, timeout)
       end
     end
 
-    def get_worker(batch, batch_mode: false, &block)
+    def signal_change
+      @mutex.synchronize { @condition.broadcast }
+      self
+    end
+
+    def get_worker(batch, batch_mode: false, started_at: monotonic_now, &block)
       if @worker_type == :fork
-        get_fork_worker(batch, batch_mode: batch_mode, &block)
+        get_fork_worker(batch, batch_mode: batch_mode, started_at: started_at, &block)
       else
-        get_thread_worker(batch, batch_mode: batch_mode, &block)
+        get_thread_worker(batch, batch_mode: batch_mode, started_at: started_at, &block)
       end
     end
 
-    def get_fork_worker(batch, batch_mode: false)
+    def get_fork_worker(batch, batch_mode: false, started_at: monotonic_now)
       reader, writer = IO.pipe
       pid = fork do
         reader.close
@@ -152,11 +200,17 @@ module Thimble
         exit! 0
       end
       writer.close
-      Worker.new(pid: pid, reader: reader, done: false)
+      Worker.new(
+        pid: pid,
+        reader: reader,
+        done: false,
+        started_at: started_at,
+        batch_size: batch.item.size
+      )
     end
 
-    def get_thread_worker(batch, batch_mode: false)
-      worker = Worker.new(done: false)
+    def get_thread_worker(batch, batch_mode: false, started_at: monotonic_now)
+      worker = Worker.new(done: false, started_at: started_at, batch_size: batch.item.size)
       worker.pid = Thread.new do
         begin
           worker.result = execute_batch(batch, batch_mode) { |value| yield value }
@@ -205,6 +259,13 @@ module Thimble
       raise ArgumentError, "#{name} must be an integer greater than 0"
     end
 
+    def validate_wait_timeout!(value)
+      return if value.nil?
+      return if value.is_a?(Numeric) && value >= 0 && (!value.respond_to?(:finite?) || value.finite?)
+
+      raise ArgumentError, 'timeout must be a finite number greater than or equal to 0'
+    end
+
     def worker_available_unlocked?
       @current_workers.size + @reserved_workers < @max_workers
     end
@@ -249,15 +310,38 @@ module Thimble
     end
 
     def terminate_process(pid)
-      Process.kill('TERM', pid)
-    rescue Errno::ESRCH
-      nil
-    ensure
       begin
-        Process.waitpid(pid)
-      rescue Errno::ECHILD
-        nil
+        Process.kill('TERM', pid)
+      rescue Errno::ESRCH
+        # The child may have exited but still needs to be reaped.
       end
+
+      deadline = monotonic_now + PROCESS_TERM_GRACE
+      loop do
+        waited = Process.waitpid(pid, Process::WNOHANG)
+        return if waited
+        break if monotonic_now >= deadline
+
+        sleep PROCESS_WAIT_INTERVAL
+      rescue Errno::ECHILD
+        return
+      end
+
+      begin
+        Process.kill('KILL', pid)
+      rescue Errno::ESRCH
+        nil
+      ensure
+        begin
+          Process.waitpid(pid)
+        rescue Errno::ECHILD
+          nil
+        end
+      end
+    end
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
   end
 end

--- a/lib/supervision.rb
+++ b/lib/supervision.rb
@@ -1,0 +1,385 @@
+# frozen_string_literal: true
+
+module Thimble
+  class CancelledError < RuntimeError
+    attr_reader :reason
+
+    def initialize(message = 'execution cancelled', reason: nil)
+      @reason = reason
+      super(message)
+    end
+  end
+
+  class StageTimeoutError < CancelledError
+    attr_reader :execution_name, :timeout
+
+    def initialize(execution_name:, timeout:)
+      @execution_name = execution_name
+      @timeout = timeout
+      super("#{execution_name} exceeded its #{timeout}-second timeout")
+    end
+  end
+
+  class WorkerTimeoutError < StageTimeoutError
+    attr_reader :worker_id, :batch_size
+
+    def initialize(execution_name:, timeout:, worker_id:, batch_size:)
+      @worker_id = worker_id
+      @batch_size = batch_size
+      super(execution_name: execution_name, timeout: timeout)
+    end
+
+    def message
+      "#{execution_name} worker #{worker_id} exceeded its #{timeout}-second timeout while processing #{batch_size} item(s)"
+    end
+  end
+
+  class CancellationToken
+    class Subscription
+      def initialize(token, id)
+        @token = token
+        @id = id
+      end
+
+      def unsubscribe
+        return false unless @token
+
+        removed = @token.__send__(:unsubscribe, @id)
+        @token = nil
+        removed
+      end
+    end
+
+    def initialize
+      @mutex = Mutex.new
+      @condition = ConditionVariable.new
+      @error = nil
+      @callbacks = {}
+      @next_callback_id = 0
+    end
+
+    def cancel(reason = nil)
+      error = normalize_error(reason)
+      callbacks = nil
+
+      changed = @mutex.synchronize do
+        next false if @error
+
+        @error = error
+        callbacks = @callbacks.values
+        @callbacks.clear
+        @condition.broadcast
+        true
+      end
+      return false unless changed
+
+      callbacks.each do |callback|
+        callback.call(error)
+      rescue StandardError
+        # Cancellation must reach every subscriber even if one callback fails.
+        nil
+      end
+      true
+    end
+
+    def cancelled?
+      @mutex.synchronize { !@error.nil? }
+    end
+    alias canceled? cancelled?
+
+    def error
+      @mutex.synchronize { @error }
+    end
+
+    def checkpoint!
+      cancellation = error
+      raise cancellation if cancellation
+
+      self
+    end
+
+    def wait(timeout: nil)
+      validate_wait_timeout!(timeout)
+      deadline = monotonic_now + timeout if timeout
+
+      @mutex.synchronize do
+        until @error
+          remaining = deadline && deadline - monotonic_now
+          return nil if remaining && remaining <= 0
+
+          @condition.wait(@mutex, remaining)
+        end
+        @error
+      end
+    end
+
+    def on_cancel(&block)
+      raise ArgumentError, 'on_cancel requires a block' unless block
+
+      cancellation = nil
+      subscription = @mutex.synchronize do
+        if @error
+          cancellation = @error
+          nil
+        else
+          @next_callback_id += 1
+          id = @next_callback_id
+          @callbacks[id] = block
+          Subscription.new(self, id)
+        end
+      end
+
+      block.call(cancellation) if cancellation
+      subscription
+    end
+
+    private
+
+    def unsubscribe(id)
+      @mutex.synchronize { !@callbacks.delete(id).nil? }
+    end
+
+    def normalize_error(reason)
+      return CancelledError.new if reason.nil?
+      return reason if reason.is_a?(Exception)
+
+      CancelledError.new("execution cancelled: #{reason}", reason: reason)
+    end
+
+    def validate_wait_timeout!(timeout)
+      return if timeout.nil?
+      return if timeout.is_a?(Numeric) && timeout >= 0 && (!timeout.respond_to?(:finite?) || timeout.finite?)
+
+      raise ArgumentError, 'timeout must be a finite number greater than or equal to 0'
+    end
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+  end
+
+  class Execution
+    STATES = %i[pending running cancelling succeeded failed cancelled timed_out].freeze
+    TERMINAL_STATES = %i[succeeded failed cancelled timed_out].freeze
+
+    attr_reader :name, :timeout, :token
+
+    def initialize(name:, timeout: nil, token: nil)
+      validate_timeout!(timeout, allow_nil: true)
+      unless token.nil? || token.is_a?(CancellationToken)
+        raise ArgumentError, 'cancellation must be a Thimble::CancellationToken'
+      end
+
+      @name = name
+      @timeout = timeout
+      @token = token || CancellationToken.new
+      @mutex = Mutex.new
+      @condition = ConditionVariable.new
+      @state = :pending
+      @error = nil
+      @started_at = nil
+      @finished_at = nil
+      @started_monotonic = nil
+      @deadline_monotonic = nil
+
+      @token_subscription = @token.on_cancel do |error|
+        @mutex.synchronize do
+          next if terminal_unlocked?
+
+          @state = :cancelling
+          @error ||= error
+          @condition.broadcast
+        end
+      end
+    end
+
+    def start!
+      @mutex.synchronize do
+        raise RuntimeError, "#{name} has already finished" if terminal_unlocked?
+
+        unless @started_at
+          @started_at = Time.now
+          @started_monotonic = monotonic_now
+          @deadline_monotonic = @started_monotonic + timeout if timeout
+        end
+        @state = :running unless @token.cancelled?
+        @condition.broadcast
+      end
+      checkpoint!
+      self
+    end
+
+    def checkpoint!
+      deadline = @mutex.synchronize { @deadline_monotonic }
+      if deadline && monotonic_now >= deadline && !@token.cancelled?
+        @token.cancel(StageTimeoutError.new(execution_name: name, timeout: timeout))
+      end
+      @token.checkpoint!
+      self
+    end
+
+    def cancel(reason = nil)
+      return false if finished?
+
+      @token.cancel(cancellation_error(reason))
+    end
+
+    def succeed!
+      checkpoint!
+      @mutex.synchronize do
+        return self if @state == :succeeded
+        raise @error if @state == :cancelling && @error
+        raise RuntimeError, "#{name} has already finished as #{@state}" if terminal_unlocked?
+
+        @state = :succeeded
+        @finished_at = Time.now
+        @condition.broadcast
+      end
+      release_token_subscription
+      self
+    end
+
+    def fail!(error)
+      raise ArgumentError, 'error must be an Exception' unless error.is_a?(Exception)
+      return self if finished?
+
+      @token.cancel(error) unless @token.cancelled?
+      terminal_error = @token.error || error
+
+      @mutex.synchronize do
+        unless terminal_unlocked?
+          @error = terminal_error
+          @state = terminal_state_for(terminal_error)
+          @finished_at = Time.now
+          @condition.broadcast
+        end
+      end
+      release_token_subscription
+      self
+    end
+
+    def wait(timeout: nil)
+      validate_wait_timeout!(timeout)
+      deadline = monotonic_now + timeout if timeout
+
+      @mutex.synchronize do
+        until terminal_unlocked?
+          remaining = deadline && deadline - monotonic_now
+          return nil if remaining && remaining <= 0
+
+          @condition.wait(@mutex, remaining)
+        end
+      end
+      self
+    end
+
+    def state
+      @mutex.synchronize { @state }
+    end
+
+    def error
+      @mutex.synchronize { @error }
+    end
+
+    def started_at
+      @mutex.synchronize { @started_at }
+    end
+
+    def finished_at
+      @mutex.synchronize { @finished_at }
+    end
+
+    def duration
+      started_monotonic, started_wall, finished_wall = @mutex.synchronize do
+        [@started_monotonic, @started_at, @finished_at]
+      end
+      return nil unless started_monotonic
+
+      finished_wall ? finished_wall - started_wall : monotonic_now - started_monotonic
+    end
+
+    def remaining_time
+      deadline = @mutex.synchronize { @deadline_monotonic }
+      return nil unless deadline
+
+      [deadline - monotonic_now, 0.0].max
+    end
+
+    def finished?
+      @mutex.synchronize { terminal_unlocked? }
+    end
+
+    def running?
+      state == :running
+    end
+
+    def succeeded?
+      state == :succeeded
+    end
+
+    def failed?
+      state == :failed
+    end
+
+    def cancelled?
+      state == :cancelled
+    end
+    alias canceled? cancelled?
+
+    def timed_out?
+      state == :timed_out
+    end
+
+    private
+
+    def cancellation_error(reason)
+      return reason if reason.is_a?(CancelledError)
+      return CancelledError.new if reason.nil?
+
+      message = if reason.is_a?(Exception)
+                  "execution cancelled: #{reason.class}: #{reason.message}"
+                else
+                  "execution cancelled: #{reason}"
+                end
+      CancelledError.new(message, reason: reason)
+    end
+
+    def terminal_state_for(error)
+      case error
+      when StageTimeoutError
+        :timed_out
+      when CancelledError
+        :cancelled
+      else
+        :failed
+      end
+    end
+
+    def terminal_unlocked?
+      TERMINAL_STATES.include?(@state)
+    end
+
+    def release_token_subscription
+      @token_subscription&.unsubscribe
+      @token_subscription = nil
+    end
+
+    def validate_timeout!(value, allow_nil:)
+      return if allow_nil && value.nil?
+      return if value.is_a?(Numeric) && value.positive? && (!value.respond_to?(:finite?) || value.finite?)
+
+      raise ArgumentError, 'timeout must be a finite number greater than 0'
+    end
+
+    def validate_wait_timeout!(value)
+      return if value.nil?
+      return if value.is_a?(Numeric) && value >= 0 && (!value.respond_to?(:finite?) || value.finite?)
+
+      raise ArgumentError, 'timeout must be a finite number greater than or equal to 0'
+    end
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+  end
+end

--- a/lib/thimble.rb
+++ b/lib/thimble.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'supervision'
 require_relative 'manager'
 require_relative 'thimble_queue'
 require_relative 'queue_item'
@@ -26,30 +27,61 @@ module Thimble
       @result = result
       @source = enumerable
       @source_thread = nil
+      @coordinator_thread = nil
+      @cancel_subscription = nil
+      @worker_timeout = nil
       @started = false
       super(@manager.queue_size, name)
     end
 
     # Transforms each item and returns a result queue after all work finishes.
-    def map(&block)
-      start_sync(:map, batch_mode: false, &block)
+    def map(timeout: nil, worker_timeout: nil, cancellation: nil, &block)
+      start_sync(
+        :map,
+        batch_mode: false,
+        timeout: timeout,
+        worker_timeout: worker_timeout,
+        cancellation: cancellation,
+        &block
+      )
     end
 
     # Sends each worker one array of up to Manager#batch_size items. This is
     # useful for bulk APIs, database writes, and other amortized operations.
-    def map_batches(&block)
-      start_sync(:map_batches, batch_mode: true, &block)
+    def map_batches(timeout: nil, worker_timeout: nil, cancellation: nil, &block)
+      start_sync(
+        :map_batches,
+        batch_mode: true,
+        timeout: timeout,
+        worker_timeout: worker_timeout,
+        cancellation: cancellation,
+        &block
+      )
     end
 
     # Runs #map in a coordinator thread and returns a bounded result queue
     # immediately. Consuming the result provides downstream backpressure.
-    def map_async(&block)
-      start_async(:map_async, batch_mode: false, &block)
+    def map_async(timeout: nil, worker_timeout: nil, cancellation: nil, &block)
+      start_async(
+        :map_async,
+        batch_mode: false,
+        timeout: timeout,
+        worker_timeout: worker_timeout,
+        cancellation: cancellation,
+        &block
+      )
     end
 
     # Asynchronous form of #map_batches.
-    def map_batches_async(&block)
-      start_async(:map_batches_async, batch_mode: true, &block)
+    def map_batches_async(timeout: nil, worker_timeout: nil, cancellation: nil, &block)
+      start_async(
+        :map_batches_async,
+        batch_mode: true,
+        timeout: timeout,
+        worker_timeout: worker_timeout,
+        cancellation: cancellation,
+        &block
+      )
     end
 
     def self.async(&block)
@@ -58,24 +90,57 @@ module Thimble
 
     private
 
-    def start_sync(method_name, batch_mode:, &block)
+    def start_sync(method_name, batch_mode:, timeout:, worker_timeout:, cancellation:, &block)
       validate_start!(method_name, block)
       capacity = sync_result_capacity
+      prepare_execution(
+        method_name,
+        timeout: timeout,
+        worker_timeout: worker_timeout,
+        cancellation: cancellation
+      )
       @started = true
       ensure_result(capacity)
-      start_source
-      run_map(batch_mode: batch_mode, &block)
+      attach_execution_queues
+      install_cancel_handler
+
+      begin
+        @execution.start!
+        start_source
+        run_map(batch_mode: batch_mode, &block)
+      rescue Exception => error # rubocop:disable Lint/RescueException -- preserve cancellation and interrupts
+        effective_error = handle_failure(error)
+        raise effective_error
+      end
     end
 
-    def start_async(method_name, batch_mode:, &block)
+    def start_async(method_name, batch_mode:, timeout:, worker_timeout:, cancellation:, &block)
       validate_start!(method_name, block)
+      prepare_execution(
+        method_name,
+        timeout: timeout,
+        worker_timeout: worker_timeout,
+        cancellation: cancellation
+      )
       @started = true
       ensure_result(@manager.queue_size)
-      start_source
-      Thimble.async do
-        run_map(batch_mode: batch_mode, &block)
-      rescue Exception # rubocop:disable Lint/RescueException -- result queue already carries the failure
-        nil
+      attach_execution_queues
+      install_cancel_handler
+
+      begin
+        @execution.start!
+        start_source
+      rescue Exception => error # rubocop:disable Lint/RescueException -- async failures travel through the result queue
+        handle_failure(error)
+        return @result
+      end
+
+      @coordinator_thread = Thimble.async do
+        begin
+          run_map(batch_mode: batch_mode, &block)
+        rescue Exception => error # rubocop:disable Lint/RescueException -- result queue carries the failure
+          handle_failure(error)
+        end
       end
       @result
     end
@@ -85,13 +150,43 @@ module Thimble
       raise RuntimeError, 'this Thimble has already been consumed' if @started
     end
 
+    def prepare_execution(method_name, timeout:, worker_timeout:, cancellation:)
+      validate_timeout_option!(:worker_timeout, worker_timeout)
+      token = cancellation || CancellationToken.new
+      unless token.is_a?(CancellationToken)
+        raise ArgumentError, 'cancellation must be a Thimble::CancellationToken'
+      end
+
+      @worker_timeout = worker_timeout
+      @execution = Execution.new(name: "#{@name}.#{method_name}", timeout: timeout, token: token)
+    end
+
+    def attach_execution_queues
+      attach_execution(@execution)
+      @result.attach_execution(@execution)
+    end
+
+    def install_cancel_handler
+      @cancel_subscription = @execution.token.on_cancel do |error|
+        next if @execution.finished?
+
+        abort(error) unless closed?
+        @result.abort(error) unless @result.closed?
+        @manager.signal_change
+      end
+    end
+
     def start_source
       @source_thread = Thread.new do
         begin
-          @source.each { |item| push(item) }
-          close
-        rescue Exception => error # rubocop:disable Lint/RescueException -- propagate source failures through the queue
-          abort(error) unless aborted?
+          @source.each do |item|
+            @execution.checkpoint!
+            push(item, control: @execution)
+          end
+          close unless closed?
+        rescue Exception => error # rubocop:disable Lint/RescueException -- source failures propagate through the queue
+          abort(error) unless closed?
+          @manager.signal_change
         end
       end
     end
@@ -114,9 +209,13 @@ module Thimble
       input_exhausted = false
 
       loop do
+        @execution.checkpoint!
         @manager.completed_workers(@id).each { |worker| get_result(worker) }
+        @execution.checkpoint!
+        raise_worker_timeout!
 
         until input_exhausted || !@manager.worker_available?
+          @execution.checkpoint!
           pending_batch ||= get_batch
           if pending_batch.nil?
             input_exhausted = true
@@ -131,24 +230,25 @@ module Thimble
 
         break if input_exhausted && !@manager.working_for?(@id)
 
-        @manager.wait_for_change(@id, wait_for_capacity: !input_exhausted)
+        @manager.wait_for_change(
+          @id,
+          wait_for_capacity: !input_exhausted,
+          timeout: next_wait_timeout
+        )
       end
 
+      @execution.checkpoint!
       @source_thread.join
+      @execution.succeed!
       @result.close
+      release_cancel_subscription
       @result
-    rescue Exception => error # rubocop:disable Lint/RescueException -- preserve worker failures and interrupts
-      abort(error) unless closed?
-      @source_thread.join
-      @manager.stop_workers(@id)
-      @result.abort(error) unless @result.closed?
-      raise
     end
 
     def get_batch
       batch = []
       while batch.size < @manager.batch_size
-        item = self.next
+        item = self.next(control: @execution)
         if item.nil?
           return nil if batch.empty?
 
@@ -157,6 +257,27 @@ module Thimble
         batch << item
       end
       QueueItem.new(batch, 'Batch')
+    end
+
+    def raise_worker_timeout!
+      worker = @manager.timed_out_workers(@id, @worker_timeout).first
+      return unless worker
+
+      worker_id = worker.pid.is_a?(Thread) ? worker.pid.object_id : worker.pid
+      raise WorkerTimeoutError.new(
+        execution_name: @execution.name,
+        timeout: @worker_timeout,
+        worker_id: worker_id,
+        batch_size: worker.batch_size
+      )
+    end
+
+    def next_wait_timeout
+      waits = [
+        @execution.remaining_time,
+        @manager.time_until_worker_timeout(@id, @worker_timeout)
+      ].compact
+      waits.empty? ? nil : waits.min
     end
 
     def get_result(worker)
@@ -197,10 +318,45 @@ module Thimble
 
     def push_result(result)
       if result.respond_to?(:each)
-        result.each { |item| @result.push(item) }
+        result.each { |item| @result.push(item, control: @execution) }
       else
-        @result.push(result)
+        @result.push(result, control: @execution)
       end
+    end
+
+    def handle_failure(error)
+      effective_error = @execution.token.error || error
+      @execution.token.cancel(effective_error) unless @execution.token.cancelled?
+      effective_error = @execution.token.error || effective_error
+
+      abort(effective_error) unless closed?
+      @result.abort(effective_error) unless @result.closed?
+      @manager.signal_change
+      stop_source
+      @manager.stop_workers(@id)
+      @execution.fail!(effective_error) unless @execution.finished?
+      release_cancel_subscription
+      effective_error
+    end
+
+    def stop_source
+      return unless @source_thread
+      return if @source_thread.equal?(Thread.current)
+
+      @source_thread.kill if @source_thread.alive?
+      @source_thread.join
+    end
+
+    def release_cancel_subscription
+      @cancel_subscription&.unsubscribe
+      @cancel_subscription = nil
+    end
+
+    def validate_timeout_option!(name, value)
+      return if value.nil?
+      return if value.is_a?(Numeric) && value.positive? && (!value.respond_to?(:finite?) || value.finite?)
+
+      raise ArgumentError, "#{name} must be a finite number greater than 0"
     end
   end
 end

--- a/lib/thimble_queue.rb
+++ b/lib/thimble_queue.rb
@@ -3,6 +3,7 @@
 require 'logger'
 require 'securerandom'
 require_relative 'queue_item'
+require_relative 'supervision'
 
 module Thimble
   class ClosedQueueError < RuntimeError; end
@@ -10,7 +11,7 @@ module Thimble
   class ThimbleQueue
     include Enumerable
 
-    attr_reader :capacity
+    attr_reader :capacity, :execution
 
     def initialize(size, name, logger: nil)
       unless size.is_a?(Integer) && size.positive?
@@ -29,6 +30,7 @@ module Thimble
       @full = ConditionVariable.new
       @logger = logger || Logger.new($stdout)
       @logger.level = Logger::UNKNOWN
+      @execution = nil
     end
 
     # Compatibility: historically #size and #length reported capacity, not depth.
@@ -55,6 +57,68 @@ module Thimble
       self
     end
 
+    def attach_execution(execution)
+      unless execution.is_a?(Execution)
+        raise ArgumentError, 'execution must be a Thimble::Execution'
+      end
+
+      @mutex.synchronize do
+        if @execution && !@execution.equal?(execution)
+          raise RuntimeError, 'queue is already attached to another execution'
+        end
+        @execution = execution
+      end
+      self
+    end
+
+    def cancel(reason = nil)
+      raise RuntimeError, 'queue is not attached to an execution' unless @execution
+
+      @execution.cancel(reason)
+    end
+
+    def wait(timeout: nil)
+      raise RuntimeError, 'queue is not attached to an execution' unless @execution
+
+      @execution.wait(timeout: timeout)
+    end
+
+    def state
+      @execution&.state
+    end
+
+    def error
+      execution_error = @execution&.error
+      return execution_error if execution_error
+
+      @mutex.synchronize { @error }
+    end
+
+    def finished?
+      @execution&.finished? || false
+    end
+
+    def running?
+      @execution&.running? || false
+    end
+
+    def succeeded?
+      @execution&.succeeded? || false
+    end
+
+    def failed?
+      @execution&.failed? || false
+    end
+
+    def cancelled?
+      @execution&.cancelled? || false
+    end
+    alias canceled? cancelled?
+
+    def timed_out?
+      @execution&.timed_out? || false
+    end
+
     def each
       return enum_for(:each) unless block_given?
 
@@ -75,42 +139,54 @@ module Thimble
       merged_thimble
     end
 
-    def next
-      @mutex.synchronize do
-        loop do
+    def next(control: nil)
+      loop do
+        control&.checkpoint!
+        wait_timeout = control&.remaining_time
+
+        action, item = @mutex.synchronize do
           raise @error if @error
 
           unless @queue.empty?
-            item = @queue.shift
-            @logger.debug("#{@name}'s queue shifted to: #{item}")
+            value = @queue.shift
+            @logger.debug("#{@name}'s queue shifted to: #{value}")
             @full.signal
-            return item
+            next [:item, value]
           end
 
-          return nil if @closed
+          next [:closed, nil] if @closed
 
-          @empty.wait(@mutex)
+          @empty.wait(@mutex, wait_timeout)
+          [:retry, nil]
         end
+
+        return item if action == :item
+        return nil if action == :closed
       end
     end
 
-    def push(input_item)
+    def push(input_item, control: nil)
       @logger.debug("Pushing into #{@name} values: #{input_item}")
 
-      @mutex.synchronize do
-        loop do
+      loop do
+        control&.checkpoint!
+        wait_timeout = control&.remaining_time
+
+        action = @mutex.synchronize do
           raise @error if @error
           raise ClosedQueueError, "#{@name} is closed" if @closed
 
           if @queue.size < @capacity
             @queue << QueueItem.new(input_item)
             @empty.signal
-            break
+            next :pushed
           end
 
           @logger.debug("#{@name} is waiting on full")
-          @full.wait(@mutex)
+          @full.wait(@mutex, wait_timeout)
+          :retry
         end
+        break if action == :pushed
       end
 
       @logger.debug("Finished pushing into #{@name}: #{input_item}")
@@ -118,11 +194,11 @@ module Thimble
     end
 
     # Flattens the outer enumerable by one level and pushes each value.
-    def push_flat(input_item)
+    def push_flat(input_item, control: nil)
       if input_item.respond_to?(:each)
-        input_item.each { |item| push(item) }
+        input_item.each { |item| push(item, control: control) }
       else
-        push(input_item)
+        push(input_item, control: control)
       end
       self
     end
@@ -132,6 +208,8 @@ module Thimble
 
       @logger.debug("#{@name} is closing")
       @mutex.synchronize do
+        next if @closed
+
         @closed = true
         if now
           @close_now = true
@@ -145,11 +223,13 @@ module Thimble
     end
 
     # Terminates the queue immediately and propagates +error+ to blocked and
-    # future consumers/producers.
+    # future consumers/producers. The first terminal state wins.
     def abort(error)
       raise ArgumentError, 'error must be an Exception' unless error.is_a?(Exception)
 
       @mutex.synchronize do
+        next if @closed
+
         @error = error
         @closed = true
         @close_now = true

--- a/spec/supervision_spec.rb
+++ b/spec/supervision_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require 'thimble'
+
+RSpec.describe 'Thimble supervision' do
+  describe Thimble::CancellationToken do
+    it 'cancels once, wakes waiters, and raises at checkpoints' do
+      token = described_class.new
+      observed = Queue.new
+      waiter = Thread.new { observed << token.wait(timeout: 1) }
+
+      expect(token.cancel('operator stop')).to be(true)
+      expect(token.cancel('second stop')).to be(false)
+
+      error = Timeout.timeout(1) { observed.pop }
+      expect(error).to be_a(Thimble::CancelledError)
+      expect(error.message).to include('operator stop')
+      expect { token.checkpoint! }.to raise_error(Thimble::CancelledError, /operator stop/)
+      waiter.join
+    end
+
+    it 'supports cancellation callbacks that can be unsubscribed' do
+      token = described_class.new
+      observed = []
+      subscription = token.on_cancel { |error| observed << error }
+
+      expect(subscription.unsubscribe).to be(true)
+      token.cancel
+
+      expect(observed).to be_empty
+    end
+  end
+
+  describe Thimble::Execution do
+    it 'records successful lifecycle state and timing' do
+      execution = described_class.new(name: 'test stage')
+
+      expect(execution.state).to eq(:pending)
+      execution.start!
+      expect(execution).to be_running
+      execution.succeed!
+
+      expect(execution.wait(timeout: 0)).to equal(execution)
+      expect(execution).to be_succeeded
+      expect(execution.started_at).to be_a(Time)
+      expect(execution.finished_at).to be_a(Time)
+      expect(execution.duration).to be >= 0
+    end
+
+    it 'returns nil when a lifecycle wait reaches its own observation timeout' do
+      execution = described_class.new(name: 'waiting').start!
+
+      expect(execution.wait(timeout: 0.01)).to be_nil
+      execution.cancel
+      execution.fail!(execution.token.error)
+    end
+  end
+
+  describe 'supervised transformations' do
+    it 'exposes execution state and cancellation through an async result queue' do
+      manager = Thimble::Manager.new(max_workers: 1, batch_size: 1, queue_size: 1, worker_type: :thread)
+      entered = Queue.new
+      result = Thimble::Thimble.new([1], manager).map_async do |value|
+        entered << true
+        Queue.new.pop
+        value
+      end
+      Timeout.timeout(1) { entered.pop }
+
+      expect(result).to be_running
+      expect(result.cancel('manual shutdown')).to be(true)
+      expect { result.to_a }.to raise_error(Thimble::CancelledError, /manual shutdown/)
+      expect(result.wait(timeout: 1)).to equal(result.execution)
+      expect(result).to be_cancelled
+      expect(manager).not_to be_working
+    end
+
+    it 'cancels connected stages through a shared token' do
+      token = Thimble::CancellationToken.new
+      entered = Queue.new
+      first_manager = Thimble::Manager.new(max_workers: 1, batch_size: 1, queue_size: 1, worker_type: :thread)
+      second_manager = Thimble::Manager.new(max_workers: 1, batch_size: 1, queue_size: 1, worker_type: :thread)
+
+      first = Thimble::Thimble.new([1], first_manager)
+      intermediate = first.map_async(cancellation: token) do |value|
+        entered << true
+        Queue.new.pop
+        value
+      end
+      second = Thimble::Thimble.new(intermediate, second_manager)
+      output = second.map_async(cancellation: token) { |value| value }
+      Timeout.timeout(1) { entered.pop }
+
+      token.cancel('pipeline stop')
+
+      expect { output.to_a }.to raise_error(Thimble::CancelledError, /pipeline stop/)
+      expect(first.execution.wait(timeout: 1)).to equal(first.execution)
+      expect(second.execution.wait(timeout: 1)).to equal(second.execution)
+      expect(first.execution).to be_cancelled
+      expect(second.execution).to be_cancelled
+      expect(first_manager).not_to be_working
+      expect(second_manager).not_to be_working
+    end
+
+    it 'enforces a stage timeout while a worker is blocked' do
+      manager = Thimble::Manager.new(max_workers: 1, batch_size: 1, queue_size: 1, worker_type: :thread)
+      result = Thimble::Thimble.new([1], manager).map_async(timeout: 0.05) do |value|
+        Queue.new.pop
+        value
+      end
+
+      expect { result.to_a }.to raise_error(Thimble::StageTimeoutError, /0.05-second timeout/)
+      expect(result.wait(timeout: 1)).to equal(result.execution)
+      expect(result).to be_timed_out
+      expect(manager).not_to be_working
+    end
+
+    it 'enforces a per-worker timeout independently of the stage deadline' do
+      manager = Thimble::Manager.new(max_workers: 1, batch_size: 1, queue_size: 1, worker_type: :thread)
+      result = Thimble::Thimble.new([1], manager).map_async(worker_timeout: 0.05) do |value|
+        Queue.new.pop
+        value
+      end
+
+      expect do
+        result.to_a
+      end.to raise_error(Thimble::WorkerTimeoutError, /processing 1 item/)
+      expect(result.wait(timeout: 1)).to equal(result.execution)
+      expect(result).to be_timed_out
+      expect(result.error).to be_a(Thimble::WorkerTimeoutError)
+      expect(manager).not_to be_working
+    end
+
+    it 'times out while downstream backpressure blocks result delivery' do
+      manager = Thimble::Manager.new(max_workers: 2, batch_size: 1, queue_size: 1, worker_type: :thread)
+      result = Thimble::Thimble.new((1..20).to_a, manager).map_async(timeout: 0.05) { |value| value }
+
+      expect(result.wait(timeout: 1)).to equal(result.execution)
+      expect(result).to be_timed_out
+      expect { result.to_a }.to raise_error(Thimble::StageTimeoutError)
+      expect(manager).not_to be_working
+    end
+
+    it 'interrupts and reaps a timed-out fork worker' do
+      skip 'fork is not available on this platform' unless Process.respond_to?(:fork)
+
+      manager = Thimble::Manager.new(max_workers: 1, batch_size: 1, queue_size: 1, worker_type: :fork)
+      result = Thimble::Thimble.new([1], manager).map_async(worker_timeout: 0.05) do |value|
+        Signal.trap('TERM', 'IGNORE')
+        sleep 10
+        value
+      end
+
+      expect { result.to_a }.to raise_error(Thimble::WorkerTimeoutError)
+      expect(result.wait(timeout: 2)).to equal(result.execution)
+      expect(manager).not_to be_working
+      expect { Process.waitpid(-1, Process::WNOHANG) }.to raise_error(Errno::ECHILD)
+    end
+
+    it 'validates supervision options before starting work' do
+      manager = Thimble::Manager.new(worker_type: :thread)
+
+      expect do
+        Thimble::Thimble.new([1], manager).map_async(timeout: 0) { |value| value }
+      end.to raise_error(ArgumentError, /timeout/)
+      expect do
+        Thimble::Thimble.new([1], manager).map_async(worker_timeout: -1) { |value| value }
+      end.to raise_error(ArgumentError, /worker_timeout/)
+      expect do
+        Thimble::Thimble.new([1], manager).map_async(cancellation: Object.new) { |value| value }
+      end.to raise_error(ArgumentError, /CancellationToken/)
+    end
+  end
+end


### PR DESCRIPTION
## Why

PR #3 established real bounded streaming, backpressure, and deterministic worker cleanup, but a pipeline could still wait forever when:

- a source stopped producing;
- a worker blocked in an external call;
- a downstream consumer stopped draining a bounded result queue;
- an operator or service shutdown needed to stop several connected stages together.

This is the next contained pipeline-supervision slice from `ROADMAP.md`. It adds explicit lifecycle and deadline semantics without yet coupling them to retry policy or a larger pipeline DSL.

## What changed

### Execution lifecycle

- add `Thimble::Execution` with `pending`, `running`, `cancelling`, `succeeded`, `failed`, `cancelled`, and `timed_out` states;
- record start/finish timestamps, duration, terminal error, configured timeout, and the associated cancellation token;
- expose blocking `wait(timeout:)` and lifecycle predicates;
- attach the same execution object to a stage's source and result queues.

### Cooperative cancellation

- add `Thimble::CancellationToken` with idempotent cancellation, checkpoints, cancellation waits, and unsubscribeable callbacks;
- accept `cancellation:` on `map`, `map_async`, `map_batches`, and `map_batches_async`;
- allow one token to cancel several connected stages without process-global state;
- make queue producer/consumer waits cancellation-aware so blocked backpressure wakes immediately;
- expose `cancel`, `wait`, `state`, `error`, and lifecycle predicates through asynchronous result queues.

### Timeouts

- add `timeout:` for the complete stage, including source enumeration, worker execution, queue waits, and downstream backpressure;
- add `worker_timeout:` for one dispatched item or batch;
- report `StageTimeoutError` and `WorkerTimeoutError` with execution, worker, timeout, and batch context;
- use monotonic deadlines rather than wall-clock comparisons.

### Worker cleanup

- track each worker's start time and batch size;
- wake the coordinator at the nearest stage or worker deadline rather than polling;
- stop timed-out thread workers and join them;
- terminate fork workers with `TERM`, escalate to `KILL` after a short grace period, and reap them deterministically;
- preserve the existing shared-manager capacity accounting during cancellation and timeout cleanup.

### Documentation and roadmap

- document the lifecycle and public cancellation/timeout API;
- add examples for observing and cancelling asynchronous work;
- move lifecycle, cooperative cancellation, and timeouts into the completed roadmap foundation;
- leave graceful draining, retries/backoff, structured attempt context, and shutdown orchestration as the next supervision increment.

## Public API

All transform variants now accept optional keywords:

```ruby
result = thimble.map_async(
  timeout: 30,
  worker_timeout: 5,
  cancellation: token
) { |item| client.deliver(item) }
```

Asynchronous result queues expose their execution:

```ruby
result.state
result.wait(timeout: 35)
result.cancel('service shutdown')
result.error
result.succeeded?
result.cancelled?
result.timed_out?
```

Existing calls without these options retain their prior behavior and have no default deadline.

## Compatibility notes

- cancellation is immediate; graceful drain-versus-cancel semantics remain a follow-up;
- retries are intentionally not included in this PR;
- thread blocks may call `token.checkpoint!` for cooperative cancellation during long loops;
- fork workers cannot observe token changes made after `fork`, so the parent terminates and reaps them;
- completion wins a race with a later cancellation request, preventing successful queues from being retroactively aborted.

## Validation

- syntax checked every file under `lib/` and `spec/` on Ruby 3.3.8;
- ran a local 18-assertion supervision and compatibility harness covering thread/fork mapping, lifecycle state, cancellation, shared tokens, stage timeout, worker timeout, and child reaping;
- stress-tested 100 randomized thread maps, 25 cancellation cycles, 25 worker-timeout cycles, source and result-backpressure deadlines, 20 randomized fork maps, and 10 uncooperative fork timeouts that required `KILL` escalation;
- verified no worker registrations or child processes remained after each timeout/cancellation stress case;
- GitHub Actions runs the RSpec suite and gem build on Ruby 3.3, 3.4, and 4.0.