### PR TITLE
Complete pipeline supervision with retries and graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 - `Execution` lifecycle state, timing, wait, error, and cancellation introspection.
 - Complete-stage `timeout` and per-batch `worker_timeout` controls on every map variant.
 - Cancellation, lifecycle, and timeout helpers on asynchronous result queues.
+- Graceful drain requests with `draining` and `drained` execution states.
+- Bounded `RetryPolicy` backoff with jitter, retry classifiers, and abort classifiers.
+- `AttemptContext`, `FailureContext`, structured `WorkFailedError`, and remote failure snapshots.
+- Dead-letter sinks with explicit `failure_mode: :continue` handling.
+- `ShutdownCoordinator` for self-pipe signal handling, repeated-signal escalation, and grace-period enforcement.
 
 ### Changed
 
@@ -23,6 +28,9 @@
 - Queue close operations wake blocked producers and consumers safely.
 - Queue waits now participate in execution cancellation and deadlines without polling.
 - Fork cancellation escalates from `TERM` to `KILL` when a child does not exit promptly.
+- Graceful shutdown stops root ingress while connected queue stages drain accepted work.
+- Retry backoff participates in cancellation, stage deadlines, and worker deadlines.
+- Calls without retry or dead-letter options retain their historical worker exception types.
 - Runtime support now targets maintained Ruby releases, requiring Ruby 3.3 or newer.
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Thimble
 
-Thimble is a small Ruby runtime for **bounded concurrent pipelines**. It coordinates work across threads or forked processes while keeping queue capacity, batch size, and shared worker limits explicit.
+Thimble is a small Ruby runtime for **bounded concurrent pipelines**. It coordinates work across threads or forked processes while keeping queue capacity, batch size, shared worker limits, retries, and shutdown behavior explicit.
 
-The core use case is a pipeline where one stage discovers or reads data, a bounded queue limits how much can remain in memory, and another stage submits or writes work in controlled batches.
+The core use case is a pipeline where one stage discovers or reads data, bounded queues limit how much can remain in memory, and downstream stages submit or write work in controlled batches.
 
 ## Installation
 
@@ -39,9 +39,9 @@ results = Thimble::Thimble
 p results.to_a
 ```
 
-`queue_size` is the real capacity of the source queue. The source is enumerated lazily after processing starts, so a large finite input is not copied into an unbounded internal array.
+`queue_size` is the actual source-queue capacity. The source is enumerated lazily after processing begins, so a large finite input is not copied into an unbounded internal array.
 
-Parallel stages are unordered. Sort or attach sequence numbers when the original order matters.
+Parallel stages are unordered. Sort results or attach sequence numbers when original order matters.
 
 ## Bounded streaming pipeline
 
@@ -88,7 +88,7 @@ In this example:
 - at most 6 submission responses wait in the final result queue;
 - file contents flow directly into the submission stage;
 - each submission receives an array of up to 20 items;
-- downstream slowdown propagates back through the pipeline instead of allowing memory growth.
+- downstream slowdown propagates back through the pipeline rather than allowing memory growth.
 
 ## Item and batch operations
 
@@ -115,18 +115,19 @@ The final batch may contain fewer than `batch_size` items.
 
 Synchronous transforms buffer their complete result before returning, so their source must report a finite integer size. Use `map_async` or `map_batches_async` for enumerators, open queues, continuous sources, and other unknown-size streams.
 
-## Supervision, cancellation, and timeouts
+## Execution lifecycle, cancellation, and timeouts
 
 Every transform has a `Thimble::Execution` with an explicit lifecycle:
 
 ```text
-pending -> running -> succeeded
+pending -> running  -> succeeded
                    -> failed
-                   -> cancelled
                    -> timed_out
+        -> draining -> drained
+        -> cancelling -> cancelled
 ```
 
-Asynchronous result queues expose that execution directly and provide convenience methods such as `state`, `wait`, `cancel`, `running?`, `succeeded?`, `cancelled?`, `timed_out?`, and `error`.
+Asynchronous result queues expose that execution directly and provide convenience methods such as `state`, `wait`, `drain`, `cancel`, `running?`, `draining?`, `drained?`, `succeeded?`, `cancelled?`, `timed_out?`, and `error`.
 
 ```ruby
 result = Thimble::Thimble
@@ -146,14 +147,125 @@ The supervision options are available on `map`, `map_async`, `map_batches`, and 
 
 | Option | Meaning |
 | --- | --- |
-| `timeout` | Deadline for the complete stage, including source enumeration, worker execution, queue waits, and downstream backpressure |
-| `worker_timeout` | Maximum runtime for one dispatched worker batch |
-| `cancellation` | A shared `Thimble::CancellationToken` used to cancel related stages together |
+| `timeout` | Deadline for the complete stage, including source enumeration, retry backoff, worker execution, queue waits, and downstream backpressure |
+| `worker_timeout` | Maximum runtime for one dispatched worker batch, including its retries and backoff |
+| `cancellation` | A shared `Thimble::CancellationToken` used to stop related stages together |
 
-A shared cancellation token provides pipeline-wide cancellation without global state:
+### Graceful drain versus immediate cancellation
+
+A graceful drain stops root-source ingress at the next cooperative boundary while allowing already accepted queue items and active workers to finish:
 
 ```ruby
 token = Thimble::CancellationToken.new
+
+result = Thimble::Thimble
+  .new(source, manager)
+  .map_async(cancellation: token) { |item| process(item) }
+
+result.drain('rolling deploy')
+result.wait
+puts result.state # => :drained
+```
+
+When several stages share a token, root enumerable sources stop accepting new work and stages whose source is another `ThimbleQueue` continue draining accepted upstream items. A graceful request does not raise at `token.checkpoint!`.
+
+Immediate cancellation aborts queues, discards buffered results, stops active workers, and raises a `Thimble::CancelledError` through the result queue:
+
+```ruby
+token.cancel('forced shutdown')
+# or:
+result.cancel('forced shutdown')
+```
+
+A graceful request may be escalated later by calling `cancel`. External enumerators that are blocked inside their own code remain cooperative; use a stage timeout or `ShutdownCoordinator` grace period when shutdown must eventually become immediate.
+
+## Retries, classification, and dead letters
+
+Retries are opt-in and bounded. `max_attempts` includes the first attempt:
+
+```ruby
+policy = Thimble::RetryPolicy.new(
+  max_attempts: 4,
+  base_delay: 0.1,
+  max_delay: 2.0,
+  multiplier: 2.0,
+  jitter: 0.2,
+  retry_on: [IOError, Errno::ECONNRESET],
+  abort_on: [ArgumentError]
+)
+
+result = Thimble::Thimble
+  .new(events, manager)
+  .map_async(retry_policy: policy) do |event, attempt|
+    logger.info("attempt=#{attempt.attempt} event=#{event.id}")
+    client.deliver(event)
+  end
+```
+
+`retry_policy` accepts a `RetryPolicy`, an integer attempt count, or a hash of `RetryPolicy` options. Backoff is exponential, capped by `max_delay`, and optionally jittered. Immediate cancellation interrupts thread-worker backoff. Graceful drain allows retries for work that was already accepted.
+
+By default, a retry policy matches `StandardError` but rejects common programming and input errors such as `ArgumentError`, `TypeError`, `NameError`, `LocalJumpError`, `FrozenError`, and `ZeroDivisionError`. Supply `retry_on` and `abort_on` exception classes or callables to define workload-specific classification. `abort_on` takes precedence.
+
+When `retry_policy` is supplied, the optional second block argument is a `Thimble::AttemptContext` containing:
+
+- execution name;
+- current and maximum attempt numbers;
+- item or batch input;
+- batch size and batch mode;
+- worker type and worker identity;
+- attempt start time.
+
+Blocks that declare only one argument, including `&:method_name`, retain their existing behavior.
+
+### Structured final failure
+
+When retry or dead-letter options are enabled, an exhausted final failure raises `Thimble::WorkFailedError`. Its `failure` is a `Thimble::FailureContext`, and the original exception is installed as the Ruby exception cause when available:
+
+```ruby
+begin
+  result.to_a
+rescue Thimble::WorkFailedError => error
+  failure = error.failure
+  warn "#{failure.input_summary} failed after #{failure.attempt} attempts"
+  warn "classification=#{failure.classification} cause=#{error.cause}"
+end
+```
+
+`FailureContext` records the payload snapshot, error snapshot, attempt count, retry classification, batch metadata, worker identity, timing, and whether retries were exhausted. Thread workers retain the original input and exception. Fork workers retain them when marshalable and otherwise provide class names, bounded summaries, backtraces, and `RemoteWorkerError` reconstruction.
+
+Calls that do not enable retry, dead-letter, or failure-mode options continue raising the original worker exception type for compatibility.
+
+### Dead-letter continuation
+
+A final failure can be sent to a callable, queue, array, or other object supporting `call`, `push`, or `<<`:
+
+```ruby
+dead_letters = Queue.new
+
+result = Thimble::Thimble
+  .new(events, manager)
+  .map_async(
+    retry_policy: policy,
+    dead_letter: dead_letters,
+    failure_mode: :continue
+  ) do |event|
+    client.deliver(event)
+  end
+```
+
+`failure_mode: :continue` requires a dead-letter sink so failed work cannot disappear silently. The sink receives one `FailureContext` after classification or retry exhaustion. Without `:continue`, the sink is still notified and the stage then fails.
+
+## Coordinated process-signal shutdown
+
+`Thimble::ShutdownCoordinator` routes process signals through a self-pipe to normal Ruby thread context. The first configured signal requests graceful drain; a repeated signal or expired grace period escalates to immediate cancellation.
+
+```ruby
+token = Thimble::CancellationToken.new
+shutdown = Thimble::ShutdownCoordinator.new(
+  token: token,
+  signals: %w[INT TERM],
+  grace_period: 15
+)
 
 contents = Thimble::Thimble
   .new(paths, read_manager)
@@ -163,11 +275,16 @@ responses = Thimble::Thimble
   .new(contents, submit_manager)
   .map_batches_async(cancellation: token) { |batch| client.submit(batch) }
 
-# From a signal handler coordinator, request handler, or shutdown path:
-token.cancel('service shutdown')
+shutdown.register(contents, responses).install
+
+begin
+  responses.each { |response| record_response(response) }
+ensure
+  shutdown.close
+end
 ```
 
-Cancellation and timeout failures abort connected queues, wake blocked producers and consumers, stop active workers, and surface through the asynchronous result queue. Thread-worker blocks that perform long loops can capture the shared token and call token.checkpoint!` for cooperative cancellation. Fork workers cannot observe token changes made after the fork, so the parent terminates and reaps them when cancellation or a timeout occurs.
+Register every execution that must finish during the grace period. `install` and `close` must run on the main Ruby thread because they modify process signal handlers. `close` restores the handlers that were present before installation.
 
 ## Manager options
 
@@ -199,7 +316,7 @@ The two pipelines cannot collectively exceed four active workers.
 
 ## ThimbleQueue
 
-`ThimbleQueue is a bounded multi-producer, multi-consumer queue:
+`ThimbleQueue` is a bounded multi-producer, multi-consumer queue:
 
 ```ruby
 queue = Thimble::ThimbleQueue.new(10, 'records')
@@ -217,12 +334,13 @@ Important semantics:
 - `each`, `next`, and `to_a` consume values destructively;
 - for compatibility, `size` and `length` report capacity; use `current_size` for current depth.
 
-## Failure behavior
+## Failure and worker behavior
 
 - Worker exceptions are propagated to synchronous callers.
 - Asynchronous failures abort the result queue and are raised when the result is consumed.
-- A failed, cancelled, or timed-out stage stops its remaining workers and wakes blocked producers and consumers.
-- `Execution#error`, timestamps, duration, and terminal state preserve structured operation context.
+- A failed, immediately cancelled, or timed-out stage stops its remaining workers and wakes blocked producers and consumers.
+- A gracefully drained stage closes normally after accepted work finishes and reports `:drained` with no execution error.
+- `Execution#error`, timestamps, duration, shutdown reason, and terminal state preserve operation context.
 - Fork workers are explicitly reaped by the parent, with `TERM` followed by `KILL` escalation for uncooperative children.
 - Non-marshallable fork results become a descriptive worker error instead of silently hanging.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,23 +13,21 @@ Thimble is being developed as a bounded pipeline runtime rather than a generic r
 - explicit execution lifecycle states and timing context;
 - shared cooperative cancellation tokens;
 - complete-stage and per-worker timeouts;
-- cancellation propagation through blocked queues and connected stages.
+- cancellation propagation through blocked queues and connected stages;
+- graceful drain with explicit immediate-cancellation escalation;
+- bounded exponential retry policies with jitter and exception classification;
+- item, batch, attempt, and final-failure context;
+- dead-letter hooks with explicit continue-versus-fail behavior;
+- signal-safe shutdown coordination with grace-period escalation.
 
-## Next: complete pipeline supervision
-
-- graceful drain versus immediate cancellation;
-- retry policies with bounded exponential backoff and jitter;
-- structured item, batch, and attempt failure context;
-- configurable retry classification and dead-letter hooks;
-- signal-friendly shutdown orchestration for multiple stages.
-
-## Next: first-class stages
+## Next: first-class stages and pipeline composition
 
 - `source`, `map`, `filter`, `flat_map`, `batch`, and `sink` stages;
 - batching by item count, estimated bytes, elapsed time, and grouping key;
+- a pipeline builder that owns stage startup, dependency order, and coordinated shutdown;
 - ordered and unordered result modes;
 - named resource limits for disk, network, API, and CPU budgets;
-- a pipeline builder that preserves the existing low-level API.
+- preserve the existing low-level `Thimble` and `ThimbleQueue` APIs as building blocks.
 
 ## Next: persistent executors
 
@@ -41,7 +39,7 @@ Thimble is being developed as a bounded pipeline runtime rather than a generic r
 
 ## Later: observability and alternate runtimes
 
-- event subscriptions for queue depth, wait time, worker utilization, retries, and failures;
+- event subscriptions for queue depth, wait time, worker utilization, retries, dead letters, and failures;
 - adapters for structured logging and OpenTelemetry;
 - benchmark and allocation suites;
 - Fiber-scheduler integration for compatible I/O clients;
@@ -51,4 +49,4 @@ Thimble is being developed as a bounded pipeline runtime rather than a generic r
 
 - durable or distributed job storage;
 - replacing Sidekiq, Active Job, or message brokers;
-- hiding backpressure or retry behavior behind implicit global configuration.
+- hiding backpressure, retries, or shutdown behavior behind implicit global configuration.

--- a/lib/retry_policy.rb
+++ b/lib/retry_policy.rb
@@ -1,0 +1,363 @@
+# frozen_string_literal: true
+
+require_relative 'supervision'
+
+module Thimble
+  class RemoteWorkerError < RuntimeError
+    attr_reader :remote_class
+
+    def initialize(remote_class:, message:, backtrace: nil)
+      @remote_class = remote_class
+      super("#{remote_class}: #{message}")
+      set_backtrace(backtrace) if backtrace
+    end
+  end
+
+  class PayloadSnapshot
+    MAX_SUMMARY_LENGTH = 500
+
+    attr_reader :value, :class_name, :summary
+
+    def self.capture(value, preserve_unmarshalable: false)
+      available = preserve_unmarshalable || marshalable?(value)
+      new(
+        value: available ? value : nil,
+        class_name: value.class.name || value.class.to_s,
+        summary: summarize(value),
+        available: available
+      )
+    end
+
+    def self.marshalable?(value)
+      Marshal.dump(value)
+      true
+    rescue StandardError
+      false
+    end
+
+    def self.summarize(value)
+      summary = value.inspect
+      summary = "#{summary[0, MAX_SUMMARY_LENGTH]}…" if summary.length > MAX_SUMMARY_LENGTH
+      summary
+    rescue StandardError => error
+      "<inspect failed: #{error.class}: #{error.message}>"
+    end
+
+    def initialize(value:, class_name:, summary:, available:)
+      @value = value
+      @class_name = class_name
+      @summary = summary
+      @available = available
+    end
+
+    def available?
+      @available
+    end
+  end
+
+  class ErrorSnapshot
+    attr_reader :class_name, :message, :backtrace
+
+    def self.capture(error, preserve_unmarshalable: false)
+      available = preserve_unmarshalable || PayloadSnapshot.marshalable?(error)
+      new(
+        original: available ? error : nil,
+        class_name: error.class.name || error.class.to_s,
+        message: safe_message(error),
+        backtrace: safe_backtrace(error),
+        available: available
+      )
+    end
+
+    def self.safe_message(error)
+      error.message.to_s
+    rescue StandardError => message_error
+      "<message failed: #{message_error.class}: #{message_error.message}>"
+    end
+
+    def self.safe_backtrace(error)
+      error.backtrace
+    rescue StandardError
+      nil
+    end
+
+    def initialize(original:, class_name:, message:, backtrace:, available:)
+      @original = original
+      @class_name = class_name
+      @message = message
+      @backtrace = backtrace
+      @available = available
+    end
+
+    def available?
+      @available
+    end
+
+    def exception
+      return @original if @original
+
+      RemoteWorkerError.new(remote_class: class_name, message: message, backtrace: backtrace)
+    end
+  end
+
+  class AttemptContext
+    attr_reader :execution_name, :attempt, :max_attempts, :input, :batch_mode,
+                :batch_size, :worker_type, :worker_id, :started_at
+
+    def initialize(execution_name:, attempt:, max_attempts:, input:, batch_mode:,
+                   batch_size:, worker_type:, worker_id:, started_at:)
+      @execution_name = execution_name
+      @attempt = attempt
+      @max_attempts = max_attempts
+      @input = input
+      @batch_mode = batch_mode
+      @batch_size = batch_size
+      @worker_type = worker_type
+      @worker_id = worker_id
+      @started_at = started_at
+    end
+
+    def batch?
+      batch_mode
+    end
+
+    def first_attempt?
+      attempt == 1
+    end
+
+    def final_attempt?
+      attempt >= max_attempts
+    end
+  end
+
+  class FailureContext
+    attr_reader :execution_name, :payload, :attempt, :max_attempts, :error_snapshot,
+                :retryable, :exhausted, :batch_mode, :batch_size, :worker_type,
+                :worker_id, :started_at, :failed_at, :elapsed
+
+    def initialize(execution_name:, payload:, attempt:, max_attempts:, error_snapshot:,
+                   retryable:, exhausted:, batch_mode:, batch_size:, worker_type:,
+                   worker_id:, started_at:, failed_at:, elapsed:)
+      @execution_name = execution_name
+      @payload = payload
+      @attempt = attempt
+      @max_attempts = max_attempts
+      @error_snapshot = error_snapshot
+      @retryable = retryable
+      @exhausted = exhausted
+      @batch_mode = batch_mode
+      @batch_size = batch_size
+      @worker_type = worker_type
+      @worker_id = worker_id
+      @started_at = started_at
+      @failed_at = failed_at
+      @elapsed = elapsed
+    end
+
+    def input
+      payload.value
+    end
+
+    def input_available?
+      payload.available?
+    end
+
+    def input_class
+      payload.class_name
+    end
+
+    def input_summary
+      payload.summary
+    end
+
+    def error
+      error_snapshot.exception
+    end
+
+    def original_error_available?
+      error_snapshot.available?
+    end
+
+    def batch?
+      batch_mode
+    end
+
+    def retryable?
+      retryable
+    end
+
+    def exhausted?
+      exhausted
+    end
+
+    def classification
+      return :retry_exhausted if retryable? && exhausted?
+
+      :non_retryable
+    end
+  end
+
+  class WorkOutcome
+    attr_reader :value, :failure
+
+    def self.success(value)
+      new(value: value)
+    end
+
+    def self.failure(failure)
+      new(failure: failure)
+    end
+
+    def initialize(value: nil, failure: nil)
+      @value = value
+      @failure = failure
+    end
+
+    def success?
+      failure.nil?
+    end
+
+    def failure?
+      !success?
+    end
+  end
+
+  class WorkFailedError < RuntimeError
+    attr_reader :failure
+
+    def initialize(failure)
+      @failure = failure
+      super(
+        "#{failure.execution_name} failed after #{failure.attempt}/#{failure.max_attempts} " \
+        "attempt(s): #{failure.error_snapshot.class_name}: #{failure.error_snapshot.message}"
+      )
+    end
+  end
+
+  class DeadLetterError < RuntimeError
+    attr_reader :failure, :sink_error
+
+    def initialize(failure:, sink_error:)
+      @failure = failure
+      @sink_error = sink_error
+      super(
+        "dead-letter delivery failed for #{failure.execution_name}: " \
+        "#{sink_error.class}: #{sink_error.message}"
+      )
+    end
+  end
+
+  class RetryPolicy
+    DEFAULT_ABORT_ON = [ArgumentError, TypeError, NameError, LocalJumpError, FrozenError, ZeroDivisionError].freeze
+
+    attr_reader :max_attempts, :base_delay, :max_delay, :multiplier, :jitter
+
+    def self.coerce(value)
+      case value
+      when nil
+        new(max_attempts: 1)
+      when RetryPolicy
+        value
+      when Integer
+        new(max_attempts: value)
+      when Hash
+        new(**value.transform_keys(&:to_sym))
+      else
+        raise ArgumentError, 'retry_policy must be a Thimble::RetryPolicy, Integer, Hash, or nil'
+      end
+    end
+
+    def initialize(max_attempts:, base_delay: 0.0, max_delay: 30.0, multiplier: 2.0,
+                   jitter: 0.0, retry_on: StandardError, abort_on: DEFAULT_ABORT_ON)
+      validate_positive_integer!(:max_attempts, max_attempts)
+      validate_nonnegative_number!(:base_delay, base_delay)
+      validate_nonnegative_number!(:max_delay, max_delay)
+      validate_number!(:multiplier, multiplier) { |value| value >= 1.0 }
+      validate_number!(:jitter, jitter) { |value| value.between?(0.0, 1.0) }
+      raise ArgumentError, 'max_delay must be greater than or equal to base_delay' if max_delay < base_delay
+
+      @max_attempts = max_attempts
+      @base_delay = base_delay.to_f
+      @max_delay = max_delay.to_f
+      @multiplier = multiplier.to_f
+      @jitter = jitter.to_f
+      @retry_matchers = normalize_matchers(retry_on, :retry_on)
+      @abort_matchers = normalize_matchers(abort_on, :abort_on)
+      freeze
+    end
+
+    def retryable?(error, context = nil)
+      return false if error.is_a?(CancelledError)
+      return false if matches_any?(@abort_matchers, error, context)
+
+      matches_any?(@retry_matchers, error, context)
+    end
+
+    # +failed_attempt+ is the attempt that just failed. The returned delay is
+    # used before the next attempt and is always bounded by +max_delay+.
+    def delay_for(failed_attempt, random: Random)
+      validate_positive_integer!(:failed_attempt, failed_attempt)
+      unless random.respond_to?(:rand)
+        raise ArgumentError, 'random must respond to #rand'
+      end
+
+      uncapped = base_delay * (multiplier**(failed_attempt - 1))
+      capped = [uncapped, max_delay].min
+      return capped if jitter.zero? || capped.zero?
+
+      factor = 1.0 - jitter + (2.0 * jitter * random.rand)
+      [[capped * factor, 0.0].max, max_delay].min
+    end
+
+    private
+
+    def normalize_matchers(value, name)
+      values = value.nil? ? [] : Array(value)
+      values.each do |matcher|
+        next if matcher.respond_to?(:call)
+        next if matcher.is_a?(Class) && matcher <= Exception
+
+        raise ArgumentError, "#{name} entries must be exception classes or callables"
+      end
+      values.freeze
+    end
+
+    def matches_any?(matchers, error, context)
+      matchers.any? do |matcher|
+        if matcher.respond_to?(:call)
+          invoke_matcher(matcher, error, context)
+        else
+          error.is_a?(matcher)
+        end
+      end
+    end
+
+    def invoke_matcher(matcher, error, context)
+      if matcher.respond_to?(:lambda?) && matcher.lambda? && matcher.arity == 1
+        matcher.call(error)
+      elsif matcher.respond_to?(:arity) && matcher.arity == 1
+        matcher.call(error)
+      else
+        matcher.call(error, context)
+      end
+    end
+
+    def validate_positive_integer!(name, value)
+      return if value.is_a?(Integer) && value.positive?
+
+      raise ArgumentError, "#{name} must be an integer greater than 0"
+    end
+
+    def validate_nonnegative_number!(name, value)
+      validate_number!(name, value) { |candidate| candidate >= 0 }
+    end
+
+    def validate_number!(name, value)
+      valid = value.is_a?(Numeric) && (!value.respond_to?(:finite?) || value.finite?)
+      valid &&= yield(value.to_f) if valid && block_given?
+      return if valid
+
+      raise ArgumentError, "#{name} is invalid"
+    end
+  end
+end

--- a/lib/shutdown_coordinator.rb
+++ b/lib/shutdown_coordinator.rb
@@ -1,0 +1,262 @@
+# frozen_string_literal: true
+
+require_relative 'supervision'
+
+module Thimble
+  class ShutdownTimeoutError < CancelledError
+    attr_reader :grace_period
+
+    def initialize(grace_period:)
+      @grace_period = grace_period
+      super("graceful shutdown exceeded its #{grace_period}-second grace period")
+    end
+  end
+
+  # Coordinates process signals with one shared CancellationToken. The first
+  # signal requests a graceful drain; a repeated signal or an expired grace
+  # period escalates to immediate cancellation.
+  class ShutdownCoordinator
+    DEFAULT_SIGNALS = %w[INT TERM].freeze
+    MONITOR_INTERVAL = 0.05
+
+    attr_reader :token, :signals, :grace_period
+
+    def initialize(token: CancellationToken.new, signals: DEFAULT_SIGNALS, grace_period: 10.0)
+      unless token.is_a?(CancellationToken)
+        raise ArgumentError, 'token must be a Thimble::CancellationToken'
+      end
+
+      validate_grace_period!(grace_period)
+      @token = token
+      @signals = normalize_signals(signals)
+      @grace_period = grace_period&.to_f
+      @mutex = Mutex.new
+      @condition = ConditionVariable.new
+      @targets = []
+      @notification_count = 0
+      @closed = false
+      @installed = false
+      @reader = nil
+      @writer = nil
+      @reader_thread = nil
+      @escalation_thread = nil
+      @previous_handlers = {}
+      @signal_by_code = {}
+    end
+
+    def register(*targets)
+      executions = targets.flatten.map { |target| normalize_execution(target) }
+      @mutex.synchronize do
+        raise RuntimeError, 'shutdown coordinator is closed' if @closed
+        if token.shutdown?
+          raise RuntimeError, 'cannot register executions after shutdown has begun'
+        end
+
+        executions.each do |execution|
+          @targets << execution unless @targets.include?(execution)
+        end
+        @condition.broadcast
+      end
+      self
+    end
+
+    def install
+      ensure_main_thread!('install')
+      @mutex.synchronize do
+        raise RuntimeError, 'shutdown coordinator is closed' if @closed
+        return self if @installed
+
+        @reader, @writer = IO.pipe
+        @signal_by_code = signals.each_with_index.to_h { |signal, index| [(index + 1).chr, signal] }
+        @installed = true
+      end
+
+      @reader_thread = Thread.new { read_signals }
+      install_signal_handlers
+      self
+    rescue Exception # rubocop:disable Lint/RescueException -- restore partial process signal state
+      close_internal(restore_handlers: true)
+      raise
+    end
+
+    alias install! install
+
+    def installed?
+      @mutex.synchronize { @installed }
+    end
+
+    # Public for embedders and deterministic tests. +signal+ may be "TERM",
+    # "SIGTERM", or a symbol.
+    def notify(signal)
+      normalized = normalize_signal(signal)
+      unless signals.include?(normalized)
+        raise ArgumentError, "signal SIG#{normalized} is not configured for this coordinator"
+      end
+
+      count = @mutex.synchronize do
+        return false if @closed
+
+        @notification_count += 1
+      end
+
+      if count == 1 && !token.shutdown?
+        changed = token.drain("received SIG#{normalized}")
+        start_escalation_timer if changed
+        changed
+      else
+        token.cancel("received SIG#{normalized} during graceful shutdown")
+      end
+    end
+
+    def close
+      ensure_main_thread!('close') if installed?
+      close_internal(restore_handlers: true)
+      self
+    end
+
+    def closed?
+      @mutex.synchronize { @closed }
+    end
+
+    def targets_finished?
+      targets = @mutex.synchronize { @targets.dup }
+      !targets.empty? && targets.all?(&:finished?)
+    end
+
+    private
+
+    def install_signal_handlers
+      signals.each_with_index do |signal, index|
+        writer = @writer
+        payload = (index + 1).chr.freeze
+        previous = Signal.trap(signal) do
+          begin
+            writer.write_nonblock(payload)
+          rescue IO::WaitWritable, Errno::EAGAIN, IOError
+            # The coordinator is already waking or closing; dropping a duplicate
+            # byte is safe because a repeated signal still reaches the shared
+            # cancellation token through the next successful notification.
+            nil
+          end
+        end
+        @previous_handlers[signal] = previous
+      end
+    end
+
+    def read_signals
+      loop do
+        code = @reader.read(1)
+        break unless code
+
+        signal = @signal_by_code[code]
+        notify(signal) if signal
+      end
+    rescue IOError, Errno::EBADF
+      nil
+    end
+
+    def start_escalation_timer
+      return unless grace_period
+
+      @mutex.synchronize do
+        return if @escalation_thread&.alive?
+
+        @escalation_thread = Thread.new do
+          deadline = monotonic_now + grace_period
+          loop do
+            break if closed? || token.cancelled? || targets_finished?
+
+            remaining = deadline - monotonic_now
+            if remaining <= 0
+              token.cancel(ShutdownTimeoutError.new(grace_period: grace_period))
+              break
+            end
+
+            @mutex.synchronize do
+              break if @closed
+
+              @condition.wait(@mutex, [remaining, MONITOR_INTERVAL].min)
+            end
+          end
+        end
+      end
+    end
+
+    def close_internal(restore_handlers:)
+      handlers = nil
+      reader_thread = nil
+      escalation_thread = nil
+      reader = nil
+      writer = nil
+
+      @mutex.synchronize do
+        return if @closed
+
+        @closed = true
+        @installed = false
+        handlers = @previous_handlers.dup
+        @previous_handlers.clear
+        reader_thread = @reader_thread
+        escalation_thread = @escalation_thread
+        reader = @reader
+        writer = @writer
+        @reader_thread = nil
+        @escalation_thread = nil
+        @reader = nil
+        @writer = nil
+        @condition.broadcast
+      end
+
+      if restore_handlers
+        handlers.each { |signal, handler| Signal.trap(signal, handler) }
+      end
+      writer&.close unless writer&.closed?
+      reader&.close unless reader&.closed?
+      reader_thread&.join unless reader_thread&.equal?(Thread.current)
+      escalation_thread&.join unless escalation_thread&.equal?(Thread.current)
+    end
+
+    def normalize_execution(target)
+      execution = target.is_a?(Execution) ? target : target.respond_to?(:execution) ? target.execution : nil
+      return execution if execution.is_a?(Execution)
+
+      raise ArgumentError, 'registered targets must be a Thimble::Execution or expose #execution'
+    end
+
+    def normalize_signals(values)
+      normalized = Array(values).map { |signal| normalize_signal(signal) }.uniq
+      raise ArgumentError, 'signals must contain at least one signal' if normalized.empty?
+
+      available = Signal.list
+      unknown = normalized.reject { |signal| available.key?(signal) }
+      unless unknown.empty?
+        raise ArgumentError, "unsupported signal(s): #{unknown.join(', ')}"
+      end
+      normalized.freeze
+    end
+
+    def normalize_signal(signal)
+      normalized = signal.to_s.upcase.sub(/\ASIG/, '')
+      raise ArgumentError, 'signal must not be empty' if normalized.empty?
+
+      normalized
+    end
+
+    def validate_grace_period!(value)
+      return if value.nil?
+      return if value.is_a?(Numeric) && value.positive? && (!value.respond_to?(:finite?) || value.finite?)
+
+      raise ArgumentError, 'grace_period must be a finite number greater than 0 or nil'
+    end
+
+    def ensure_main_thread!(operation)
+      return if Thread.current.equal?(Thread.main)
+
+      raise ThreadError, "ShutdownCoordinator##{operation} must run on the main thread"
+    end
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+  end
+end

--- a/lib/supervision.rb
+++ b/lib/supervision.rb
@@ -34,7 +34,19 @@ module Thimble
     end
   end
 
+  ShutdownRequest = Struct.new(:mode, :reason, :error, :requested_at, keyword_init: true) do
+    def graceful?
+      mode == :graceful
+    end
+
+    def immediate?
+      mode == :immediate
+    end
+  end
+
   class CancellationToken
+    MODES = %i[graceful immediate].freeze
+
     class Subscription
       def initialize(token, id)
         @token = token
@@ -53,42 +65,74 @@ module Thimble
     def initialize
       @mutex = Mutex.new
       @condition = ConditionVariable.new
-      @error = nil
+      @request = nil
       @callbacks = {}
       @next_callback_id = 0
     end
 
     def cancel(reason = nil)
-      error = normalize_error(reason)
+      request_shutdown(mode: :immediate, reason: reason)
+    end
+
+    def drain(reason = nil)
+      request_shutdown(mode: :graceful, reason: reason)
+    end
+
+    def shutdown(mode:, reason: nil)
+      request_shutdown(mode: mode, reason: reason)
+    end
+
+    def request_shutdown(mode:, reason: nil)
+      validate_mode!(mode)
+      new_request = build_request(mode, reason)
       callbacks = nil
 
       changed = @mutex.synchronize do
-        next false if @error
+        current = @request
+        next false if current&.immediate?
+        next false if current&.mode == mode
 
-        @error = error
+        @request = new_request
         callbacks = @callbacks.values
-        @callbacks.clear
+        @callbacks.clear if new_request.immediate?
         @condition.broadcast
         true
       end
       return false unless changed
 
       callbacks.each do |callback|
-        callback.call(error)
+        callback.call(new_request)
       rescue StandardError
-        # Cancellation must reach every subscriber even if one callback fails.
+        # Every subscriber must observe shutdown even if one callback fails.
         nil
       end
       true
     end
 
+    def shutdown?
+      @mutex.synchronize { !@request.nil? }
+    end
+
+    def draining?
+      @mutex.synchronize { @request&.graceful? || false }
+    end
+
     def cancelled?
-      @mutex.synchronize { !@error.nil? }
+      @mutex.synchronize { @request&.immediate? || false }
     end
     alias canceled? cancelled?
 
+    def request
+      @mutex.synchronize { @request }
+    end
+
     def error
-      @mutex.synchronize { @error }
+      current = request
+      current&.error if current&.immediate?
+    end
+
+    def reason
+      request&.reason
     end
 
     def checkpoint!
@@ -98,28 +142,55 @@ module Thimble
       self
     end
 
+    # Preserves the historical behavior: immediate cancellation returns its
+    # exception. A graceful request returns a ShutdownRequest.
     def wait(timeout: nil)
+      current = wait_for_shutdown(timeout: timeout)
+      return nil unless current
+
+      current.immediate? ? current.error : current
+    end
+
+    def wait_for_shutdown(timeout: nil)
       validate_wait_timeout!(timeout)
       deadline = monotonic_now + timeout if timeout
 
       @mutex.synchronize do
-        until @error
+        until @request
           remaining = deadline && deadline - monotonic_now
           return nil if remaining && remaining <= 0
 
           @condition.wait(@mutex, remaining)
         end
-        @error
+        @request
       end
     end
 
-    def on_cancel(&block)
-      raise ArgumentError, 'on_cancel requires a block' unless block
+    # Waits only for immediate cancellation. Graceful drain requests wake the
+    # waiter so it can re-evaluate the remaining timeout, but do not interrupt
+    # retry backoff for already accepted work.
+    def wait_for_cancel(timeout: nil)
+      validate_wait_timeout!(timeout)
+      deadline = monotonic_now + timeout if timeout
 
-      cancellation = nil
+      @mutex.synchronize do
+        until @request&.immediate?
+          remaining = deadline && deadline - monotonic_now
+          return nil if remaining && remaining <= 0
+
+          @condition.wait(@mutex, remaining)
+        end
+        @request.error
+      end
+    end
+
+    def on_shutdown(&block)
+      raise ArgumentError, 'on_shutdown requires a block' unless block
+
+      current = nil
       subscription = @mutex.synchronize do
-        if @error
-          cancellation = @error
+        current = @request
+        if current&.immediate?
           nil
         else
           @next_callback_id += 1
@@ -129,8 +200,16 @@ module Thimble
         end
       end
 
-      block.call(cancellation) if cancellation
+      block.call(current) if current
       subscription
+    end
+
+    def on_cancel(&block)
+      raise ArgumentError, 'on_cancel requires a block' unless block
+
+      on_shutdown do |shutdown_request|
+        block.call(shutdown_request.error) if shutdown_request.immediate?
+      end
     end
 
     private
@@ -139,11 +218,27 @@ module Thimble
       @mutex.synchronize { !@callbacks.delete(id).nil? }
     end
 
+    def build_request(mode, reason)
+      error = normalize_error(reason) if mode == :immediate
+      ShutdownRequest.new(
+        mode: mode,
+        reason: reason,
+        error: error,
+        requested_at: Time.now
+      )
+    end
+
     def normalize_error(reason)
       return CancelledError.new if reason.nil?
       return reason if reason.is_a?(Exception)
 
       CancelledError.new("execution cancelled: #{reason}", reason: reason)
+    end
+
+    def validate_mode!(mode)
+      return if MODES.include?(mode)
+
+      raise ArgumentError, 'shutdown mode must be :graceful or :immediate'
     end
 
     def validate_wait_timeout!(timeout)
@@ -159,8 +254,8 @@ module Thimble
   end
 
   class Execution
-    STATES = %i[pending running cancelling succeeded failed cancelled timed_out].freeze
-    TERMINAL_STATES = %i[succeeded failed cancelled timed_out].freeze
+    STATES = %i[pending running draining cancelling succeeded drained failed cancelled timed_out].freeze
+    TERMINAL_STATES = %i[succeeded drained failed cancelled timed_out].freeze
 
     attr_reader :name, :timeout, :token
 
@@ -177,17 +272,23 @@ module Thimble
       @condition = ConditionVariable.new
       @state = :pending
       @error = nil
+      @shutdown_request = nil
       @started_at = nil
       @finished_at = nil
       @started_monotonic = nil
       @deadline_monotonic = nil
 
-      @token_subscription = @token.on_cancel do |error|
+      @token_subscription = @token.on_shutdown do |request|
         @mutex.synchronize do
           next if terminal_unlocked?
 
-          @state = :cancelling
-          @error ||= error
+          @shutdown_request = request
+          if request.immediate?
+            @state = :cancelling
+            @error ||= request.error
+          elsif @state != :cancelling
+            @state = :draining
+          end
           @condition.broadcast
         end
       end
@@ -202,7 +303,7 @@ module Thimble
           @started_monotonic = monotonic_now
           @deadline_monotonic = @started_monotonic + timeout if timeout
         end
-        @state = :running unless @token.cancelled?
+        @state = @token.draining? ? :draining : :running unless @token.cancelled?
         @condition.broadcast
       end
       checkpoint!
@@ -224,14 +325,33 @@ module Thimble
       @token.cancel(cancellation_error(reason))
     end
 
+    def drain(reason = nil)
+      return false if finished?
+
+      @token.drain(reason)
+    end
+
+    def shutdown(mode:, reason: nil)
+      return false if finished?
+
+      case mode
+      when :immediate
+        cancel(reason)
+      when :graceful
+        drain(reason)
+      else
+        raise ArgumentError, 'shutdown mode must be :graceful or :immediate'
+      end
+    end
+
     def succeed!
       checkpoint!
       @mutex.synchronize do
-        return self if @state == :succeeded
+        return self if %i[succeeded drained].include?(@state)
         raise @error if @state == :cancelling && @error
         raise RuntimeError, "#{name} has already finished as #{@state}" if terminal_unlocked?
 
-        @state = :succeeded
+        @state = @token.draining? ? :drained : :succeeded
         @finished_at = Time.now
         @condition.broadcast
       end
@@ -281,6 +401,14 @@ module Thimble
       @mutex.synchronize { @error }
     end
 
+    def shutdown_request
+      @mutex.synchronize { @shutdown_request }
+    end
+
+    def shutdown_reason
+      shutdown_request&.reason
+    end
+
     def started_at
       @mutex.synchronize { @started_at }
     end
@@ -313,8 +441,16 @@ module Thimble
       state == :running
     end
 
+    def draining?
+      state == :draining
+    end
+
     def succeeded?
       state == :succeeded
+    end
+
+    def drained?
+      state == :drained
     end
 
     def failed?

--- a/lib/thimble.rb
+++ b/lib/thimble.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative 'supervision'
+require_relative 'retry_policy'
+require_relative 'shutdown_coordinator'
 require_relative 'manager'
 require_relative 'thimble_queue'
 require_relative 'queue_item'
@@ -8,6 +10,8 @@ require_relative 'thimble/version'
 
 module Thimble
   class Thimble < ThimbleQueue
+    FAILURE_MODES = %i[raise continue].freeze
+
     def initialize(enumerable, manager = Manager.new, result = nil, name = 'Main')
       raise ArgumentError, 'You need to pass a manager to Thimble!' unless manager.instance_of?(Manager)
       unless enumerable.respond_to?(:each)
@@ -26,60 +30,82 @@ module Thimble
                      end
       @result = result
       @source = enumerable
+      @source_is_queue = enumerable.is_a?(ThimbleQueue)
       @source_thread = nil
       @coordinator_thread = nil
-      @cancel_subscription = nil
+      @shutdown_subscription = nil
       @worker_timeout = nil
+      @retry_policy = RetryPolicy.coerce(nil)
+      @dead_letter = nil
+      @failure_mode = :raise
+      @structured_failures = false
+      @attempt_context_enabled = false
       @started = false
       super(@manager.queue_size, name)
     end
 
     # Transforms each item and returns a result queue after all work finishes.
-    def map(timeout: nil, worker_timeout: nil, cancellation: nil, &block)
+    def map(timeout: nil, worker_timeout: nil, cancellation: nil, retry_policy: nil,
+            dead_letter: nil, failure_mode: nil, &block)
       start_sync(
         :map,
         batch_mode: false,
         timeout: timeout,
         worker_timeout: worker_timeout,
         cancellation: cancellation,
+        retry_policy: retry_policy,
+        dead_letter: dead_letter,
+        failure_mode: failure_mode,
         &block
       )
     end
 
     # Sends each worker one array of up to Manager#batch_size items. This is
     # useful for bulk APIs, database writes, and other amortized operations.
-    def map_batches(timeout: nil, worker_timeout: nil, cancellation: nil, &block)
+    def map_batches(timeout: nil, worker_timeout: nil, cancellation: nil, retry_policy: nil,
+                    dead_letter: nil, failure_mode: nil, &block)
       start_sync(
         :map_batches,
         batch_mode: true,
         timeout: timeout,
         worker_timeout: worker_timeout,
         cancellation: cancellation,
+        retry_policy: retry_policy,
+        dead_letter: dead_letter,
+        failure_mode: failure_mode,
         &block
       )
     end
 
     # Runs #map in a coordinator thread and returns a bounded result queue
     # immediately. Consuming the result provides downstream backpressure.
-    def map_async(timeout: nil, worker_timeout: nil, cancellation: nil, &block)
+    def map_async(timeout: nil, worker_timeout: nil, cancellation: nil, retry_policy: nil,
+                  dead_letter: nil, failure_mode: nil, &block)
       start_async(
         :map_async,
         batch_mode: false,
         timeout: timeout,
         worker_timeout: worker_timeout,
         cancellation: cancellation,
+        retry_policy: retry_policy,
+        dead_letter: dead_letter,
+        failure_mode: failure_mode,
         &block
       )
     end
 
     # Asynchronous form of #map_batches.
-    def map_batches_async(timeout: nil, worker_timeout: nil, cancellation: nil, &block)
+    def map_batches_async(timeout: nil, worker_timeout: nil, cancellation: nil,
+                          retry_policy: nil, dead_letter: nil, failure_mode: nil, &block)
       start_async(
         :map_batches_async,
         batch_mode: true,
         timeout: timeout,
         worker_timeout: worker_timeout,
         cancellation: cancellation,
+        retry_policy: retry_policy,
+        dead_letter: dead_letter,
+        failure_mode: failure_mode,
         &block
       )
     end
@@ -90,19 +116,23 @@ module Thimble
 
     private
 
-    def start_sync(method_name, batch_mode:, timeout:, worker_timeout:, cancellation:, &block)
+    def start_sync(method_name, batch_mode:, timeout:, worker_timeout:, cancellation:,
+                   retry_policy:, dead_letter:, failure_mode:, &block)
       validate_start!(method_name, block)
       capacity = sync_result_capacity
       prepare_execution(
         method_name,
         timeout: timeout,
         worker_timeout: worker_timeout,
-        cancellation: cancellation
+        cancellation: cancellation,
+        retry_policy: retry_policy,
+        dead_letter: dead_letter,
+        failure_mode: failure_mode
       )
       @started = true
       ensure_result(capacity)
       attach_execution_queues
-      install_cancel_handler
+      install_shutdown_handler
 
       begin
         @execution.start!
@@ -114,18 +144,22 @@ module Thimble
       end
     end
 
-    def start_async(method_name, batch_mode:, timeout:, worker_timeout:, cancellation:, &block)
+    def start_async(method_name, batch_mode:, timeout:, worker_timeout:, cancellation:,
+                    retry_policy:, dead_letter:, failure_mode:, &block)
       validate_start!(method_name, block)
       prepare_execution(
         method_name,
         timeout: timeout,
         worker_timeout: worker_timeout,
-        cancellation: cancellation
+        cancellation: cancellation,
+        retry_policy: retry_policy,
+        dead_letter: dead_letter,
+        failure_mode: failure_mode
       )
       @started = true
       ensure_result(@manager.queue_size)
       attach_execution_queues
-      install_cancel_handler
+      install_shutdown_handler
 
       begin
         @execution.start!
@@ -150,7 +184,8 @@ module Thimble
       raise RuntimeError, 'this Thimble has already been consumed' if @started
     end
 
-    def prepare_execution(method_name, timeout:, worker_timeout:, cancellation:)
+    def prepare_execution(method_name, timeout:, worker_timeout:, cancellation:,
+                          retry_policy:, dead_letter:, failure_mode:)
       validate_timeout_option!(:worker_timeout, worker_timeout)
       token = cancellation || CancellationToken.new
       unless token.is_a?(CancellationToken)
@@ -158,6 +193,14 @@ module Thimble
       end
 
       @worker_timeout = worker_timeout
+      @retry_policy = RetryPolicy.coerce(retry_policy)
+      @failure_mode = normalize_failure_mode(failure_mode)
+      @dead_letter = validate_dead_letter!(dead_letter)
+      if @failure_mode == :continue && @dead_letter.nil?
+        raise ArgumentError, 'failure_mode :continue requires a dead_letter sink'
+      end
+      @structured_failures = !retry_policy.nil? || !dead_letter.nil? || !failure_mode.nil?
+      @attempt_context_enabled = !retry_policy.nil?
       @execution = Execution.new(name: "#{@name}.#{method_name}", timeout: timeout, token: token)
     end
 
@@ -166,12 +209,17 @@ module Thimble
       @result.attach_execution(@execution)
     end
 
-    def install_cancel_handler
-      @cancel_subscription = @execution.token.on_cancel do |error|
+    def install_shutdown_handler
+      @shutdown_subscription = @execution.token.on_shutdown do |request|
         next if @execution.finished?
 
-        abort(error) unless closed?
-        @result.abort(error) unless @result.closed?
+        if request.immediate?
+          abort(request.error) unless closed?
+          @result.abort(request.error) unless @result.closed?
+        else
+          wake_waiters
+          @result.wake_waiters
+        end
         @manager.signal_change
       end
     end
@@ -179,15 +227,38 @@ module Thimble
     def start_source
       @source_thread = Thread.new do
         begin
-          @source.each do |item|
-            @execution.checkpoint!
-            push(item, control: @execution)
+          if @source_is_queue
+            stream_queue_source
+          else
+            stream_enumerable_source
           end
           close unless closed?
+        rescue ClosedQueueError => error
+          if @execution.draining?
+            close unless closed?
+          else
+            abort(error) unless closed?
+          end
+          @manager.signal_change
         rescue Exception => error # rubocop:disable Lint/RescueException -- source failures propagate through the queue
           abort(error) unless closed?
           @manager.signal_change
         end
+      end
+    end
+
+    def stream_queue_source
+      while (queue_item = @source.next(control: @execution))
+        push(queue_item.item, control: @execution)
+      end
+    end
+
+    def stream_enumerable_source
+      @source.each do |item|
+        break if @execution.draining?
+
+        accepted = push(item, control: @execution, stop_on_drain: true)
+        break unless accepted
       end
     end
 
@@ -207,6 +278,7 @@ module Thimble
     def run_map(batch_mode:, &block)
       pending_batch = nil
       input_exhausted = false
+      worker_block = build_worker_block(batch_mode, block)
 
       loop do
         @execution.checkpoint!
@@ -222,7 +294,7 @@ module Thimble
             break
           end
 
-          worker = @manager.start_worker(pending_batch, @id, batch_mode: batch_mode, &block)
+          worker = @manager.start_worker(pending_batch, @id, batch_mode: batch_mode, &worker_block)
           break unless worker
 
           pending_batch = nil
@@ -241,7 +313,7 @@ module Thimble
       @source_thread.join
       @execution.succeed!
       @result.close
-      release_cancel_subscription
+      release_shutdown_subscription
       @result
     end
 
@@ -257,6 +329,107 @@ module Thimble
         batch << item
       end
       QueueItem.new(batch, 'Batch')
+    end
+
+    def build_worker_block(batch_mode, block)
+      proc do |input|
+        execute_with_retries(input, batch_mode: batch_mode, block: block)
+      end
+    end
+
+    def execute_with_retries(input, batch_mode:, block:)
+      attempt = 0
+      started_at = Time.now
+      started_monotonic = monotonic_now
+      batch_size = batch_mode ? input.size : 1
+      worker_id = @manager.worker_type == :thread ? Thread.current.object_id : Process.pid
+
+      loop do
+        attempt += 1
+        context = AttemptContext.new(
+          execution_name: @execution.name,
+          attempt: attempt,
+          max_attempts: @retry_policy.max_attempts,
+          input: input,
+          batch_mode: batch_mode,
+          batch_size: batch_size,
+          worker_type: @manager.worker_type,
+          worker_id: worker_id,
+          started_at: Time.now
+        )
+
+        begin
+          worker_checkpoint!
+          value = invoke_user_block(block, input, context)
+          worker_checkpoint!
+          return WorkOutcome.success(value)
+        rescue CancelledError
+          raise
+        rescue StandardError => error
+          retryable = @retry_policy.retryable?(error, context)
+          if retryable && attempt < @retry_policy.max_attempts
+            delay = @retry_policy.delay_for(attempt)
+            wait_for_retry_delay(delay)
+            worker_checkpoint!
+            next
+          end
+
+          failed_at = Time.now
+          preserve_unmarshalable = @manager.worker_type == :thread
+          failure = FailureContext.new(
+            execution_name: @execution.name,
+            payload: PayloadSnapshot.capture(input, preserve_unmarshalable: preserve_unmarshalable),
+            attempt: attempt,
+            max_attempts: @retry_policy.max_attempts,
+            error_snapshot: ErrorSnapshot.capture(error, preserve_unmarshalable: preserve_unmarshalable),
+            retryable: retryable,
+            exhausted: retryable && attempt >= @retry_policy.max_attempts,
+            batch_mode: batch_mode,
+            batch_size: batch_size,
+            worker_type: @manager.worker_type,
+            worker_id: worker_id,
+            started_at: started_at,
+            failed_at: failed_at,
+            elapsed: monotonic_now - started_monotonic
+          )
+          return WorkOutcome.failure(failure)
+        end
+      end
+    end
+
+    def worker_checkpoint!
+      # A forked child must not touch mutexes copied from a multithreaded parent.
+      # The parent coordinator enforces cancellation and deadlines for fork
+      # workers by terminating and reaping the child.
+      @execution.checkpoint! if @manager.worker_type == :thread
+    end
+
+    def wait_for_retry_delay(delay)
+      if @manager.worker_type == :thread
+        cancellation = @execution.token.wait_for_cancel(timeout: delay)
+        raise cancellation if cancellation
+      else
+        sleep(delay) if delay.positive?
+      end
+    end
+
+    def invoke_user_block(block, input, context)
+      return block.call(input, context) if @attempt_context_enabled && accepts_attempt_context?(block)
+      return block.call if block.lambda? && block.arity.zero?
+
+      block.call(input)
+    end
+
+    def accepts_attempt_context?(block)
+      parameters = block.parameters.reject { |type, _name| type == :block }
+      return false if parameters.empty?
+
+      first_type, first_name = parameters.first
+      return true if first_type == :rest && first_name
+
+      parameters.drop(1).any? do |type, name|
+        name && %i[req opt rest].include?(type)
+      end
     end
 
     def raise_worker_timeout!
@@ -298,9 +471,7 @@ module Thimble
               "worker #{worker.pid} exited without a result (status #{status.exitstatus || status.termsig})"
       end
 
-      loaded_result = Marshal.load(payload)
-      loaded_result.each { |result| raise result if result.is_a?(Exception) }
-      push_result(loaded_result)
+      consume_worker_results(Marshal.load(payload))
     ensure
       @manager.stop_worker(worker) unless reaped
       worker.reader.close unless worker.reader.closed?
@@ -311,16 +482,91 @@ module Thimble
       @manager.rem_worker(worker)
       worker.pid.join
       raise worker.error if worker.error
-      worker.result.each { |result| raise result if result.is_a?(Exception) }
 
-      push_result(worker.result)
+      consume_worker_results(worker.result)
     end
 
-    def push_result(result)
-      if result.respond_to?(:each)
-        result.each { |item| @result.push(item, control: @execution) }
+    def consume_worker_results(results)
+      # Preserve the historical all-or-fail behavior of one dispatched worker
+      # batch: do not expose successful values from that batch before checking
+      # whether another item in it failed. This matters most for asynchronous
+      # consumers, which could otherwise observe a partial batch before the
+      # result queue is aborted.
+      raw_error = results.find { |result| result.is_a?(Exception) }
+      raise raw_error if raw_error
+
+      failures = results.filter_map do |result|
+        result.failure if result.is_a?(WorkOutcome) && result.failure?
+      end
+
+      if @failure_mode == :raise && !failures.empty?
+        failures.each { |failure| deliver_dead_letter(failure) } if @dead_letter
+        raise_work_failure(failures.first)
+      end
+
+      results.each do |result|
+        if result.is_a?(WorkOutcome)
+          if result.success?
+            @result.push(result.value, control: @execution)
+          else
+            deliver_dead_letter(result.failure)
+          end
+        else
+          # Compatibility with workers constructed through the lower-level
+          # Manager API instead of Thimble's supervised wrapper.
+          @result.push(result, control: @execution)
+        end
+      end
+    end
+
+    def raise_work_failure(failure)
+      original = failure.error
+      if @structured_failures
+        raise WorkFailedError.new(failure), cause: original
+      end
+
+      raise original
+    end
+
+    def deliver_dead_letter(failure)
+      if @dead_letter.is_a?(ThimbleQueue)
+        @dead_letter.push(failure, control: @execution)
       else
-        @result.push(result, control: @execution)
+        deliver_dead_letter_callback(failure)
+      end
+    rescue StandardError => error
+      raise DeadLetterError.new(failure: failure, sink_error: error), cause: error
+    end
+
+    def deliver_dead_letter_callback(failure)
+      sink_error = nil
+      delivery = Thread.new do
+        begin
+          if @dead_letter.respond_to?(:call)
+            @dead_letter.call(failure)
+          elsif @dead_letter.respond_to?(:push)
+            @dead_letter.push(failure)
+          else
+            @dead_letter << failure
+          end
+        rescue Exception => error # rubocop:disable Lint/RescueException -- re-raised by the coordinator
+          sink_error = error
+        end
+      end
+      delivery.report_on_exception = false if delivery.respond_to?(:report_on_exception=)
+      cancellation = @execution.token.on_cancel do |_error|
+        delivery.kill if delivery.alive? && !delivery.equal?(Thread.current)
+      end
+
+      remaining = @execution.remaining_time
+      remaining ? delivery.join(remaining) : delivery.join
+      @execution.checkpoint!
+      raise sink_error if sink_error
+    ensure
+      cancellation&.unsubscribe
+      if delivery&.alive? && @execution.token.cancelled?
+        delivery.kill
+        delivery.join unless delivery.equal?(Thread.current)
       end
     end
 
@@ -335,7 +581,7 @@ module Thimble
       stop_source
       @manager.stop_workers(@id)
       @execution.fail!(effective_error) unless @execution.finished?
-      release_cancel_subscription
+      release_shutdown_subscription
       effective_error
     end
 
@@ -347,9 +593,23 @@ module Thimble
       @source_thread.join
     end
 
-    def release_cancel_subscription
-      @cancel_subscription&.unsubscribe
-      @cancel_subscription = nil
+    def release_shutdown_subscription
+      @shutdown_subscription&.unsubscribe
+      @shutdown_subscription = nil
+    end
+
+    def normalize_failure_mode(value)
+      mode = value || :raise
+      return mode if FAILURE_MODES.include?(mode)
+
+      raise ArgumentError, 'failure_mode must be :raise or :continue'
+    end
+
+    def validate_dead_letter!(sink)
+      return nil if sink.nil?
+      return sink if sink.respond_to?(:call) || sink.respond_to?(:push) || sink.respond_to?(:<<)
+
+      raise ArgumentError, 'dead_letter must respond to #call, #push, or #<<'
     end
 
     def validate_timeout_option!(name, value)
@@ -357,6 +617,10 @@ module Thimble
       return if value.is_a?(Numeric) && value.positive? && (!value.respond_to?(:finite?) || value.finite?)
 
       raise ArgumentError, "#{name} must be a finite number greater than 0"
+    end
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
   end
 end

--- a/lib/thimble_queue.rb
+++ b/lib/thimble_queue.rb
@@ -72,15 +72,19 @@ module Thimble
     end
 
     def cancel(reason = nil)
-      raise RuntimeError, 'queue is not attached to an execution' unless @execution
+      attached_execution.cancel(reason)
+    end
 
-      @execution.cancel(reason)
+    def drain(reason = nil)
+      attached_execution.drain(reason)
+    end
+
+    def shutdown(mode:, reason: nil)
+      attached_execution.shutdown(mode: mode, reason: reason)
     end
 
     def wait(timeout: nil)
-      raise RuntimeError, 'queue is not attached to an execution' unless @execution
-
-      @execution.wait(timeout: timeout)
+      attached_execution.wait(timeout: timeout)
     end
 
     def state
@@ -94,6 +98,10 @@ module Thimble
       @mutex.synchronize { @error }
     end
 
+    def shutdown_reason
+      @execution&.shutdown_reason
+    end
+
     def finished?
       @execution&.finished? || false
     end
@@ -102,8 +110,16 @@ module Thimble
       @execution&.running? || false
     end
 
+    def draining?
+      @execution&.draining? || false
+    end
+
     def succeeded?
       @execution&.succeeded? || false
+    end
+
+    def drained?
+      @execution&.drained? || false
     end
 
     def failed?
@@ -165,13 +181,17 @@ module Thimble
       end
     end
 
-    def push(input_item, control: nil)
+    # When +stop_on_drain+ is true, a graceful execution drain prevents the
+    # producer from accepting another item and returns false. This is used by
+    # root sources; downstream queue sources continue draining accepted work.
+    def push(input_item, control: nil, stop_on_drain: false)
       @logger.debug("Pushing into #{@name} values: #{input_item}")
 
       loop do
         control&.checkpoint!
-        wait_timeout = control&.remaining_time
+        return false if stop_on_drain && control&.draining?
 
+        wait_timeout = control&.remaining_time
         action = @mutex.synchronize do
           raise @error if @error
           raise ClosedQueueError, "#{@name} is closed" if @closed
@@ -194,11 +214,14 @@ module Thimble
     end
 
     # Flattens the outer enumerable by one level and pushes each value.
-    def push_flat(input_item, control: nil)
+    def push_flat(input_item, control: nil, stop_on_drain: false)
       if input_item.respond_to?(:each)
-        input_item.each { |item| push(item, control: control) }
+        input_item.each do |item|
+          accepted = push(item, control: control, stop_on_drain: stop_on_drain)
+          return false unless accepted
+        end
       else
-        push(input_item, control: control)
+        return false unless push(input_item, control: control, stop_on_drain: stop_on_drain)
       end
       self
     end
@@ -240,6 +263,17 @@ module Thimble
       self
     end
 
+    # Wakes blocked producers and consumers without changing queue state. This
+    # lets graceful shutdown requests interrupt waits so root producers can stop
+    # accepting work while consumers continue draining accepted values.
+    def wake_waiters
+      @mutex.synchronize do
+        @full.broadcast
+        @empty.broadcast
+      end
+      self
+    end
+
     def to_a
       each.to_a
     end
@@ -250,6 +284,14 @@ module Thimble
 
     def aborted?
       @mutex.synchronize { !@error.nil? }
+    end
+
+    private
+
+    def attached_execution
+      raise RuntimeError, 'queue is not attached to an execution' unless @execution
+
+      @execution
     end
   end
 end

--- a/spec/graceful_shutdown_spec.rb
+++ b/spec/graceful_shutdown_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'thimble'
+
+RSpec.describe 'Thimble graceful shutdown' do
+  describe Thimble::CancellationToken do
+    it 'supports graceful drain followed by immediate escalation' do
+      token = described_class.new
+      observed = Queue.new
+      subscription = token.on_shutdown { |request| observed << request }
+
+      expect(token.drain('deployment')).to be(true)
+      graceful = Timeout.timeout(1) { observed.pop }
+      expect(graceful).to be_graceful
+      expect(token).to be_draining
+      expect(token).not_to be_cancelled
+      expect(token.checkpoint!).to equal(token)
+      expect(token.wait(timeout: 0)).to equal(graceful)
+
+      expect(token.cancel('forced shutdown')).to be(true)
+      immediate = Timeout.timeout(1) { observed.pop }
+      expect(immediate).to be_immediate
+      expect(token).to be_cancelled
+      expect { token.checkpoint! }.to raise_error(Thimble::CancelledError, /forced shutdown/)
+      expect(subscription.unsubscribe).to be(false)
+    end
+  end
+
+  describe 'draining a stage' do
+    it 'stops root-source ingress and completes every accepted item' do
+      token = Thimble::CancellationToken.new
+      source_release = Queue.new
+      worker_entered = Queue.new
+      worker_release = Queue.new
+      source = Enumerator.new do |out|
+        out << 1
+        source_release.pop
+        out << 2
+      end
+      manager = Thimble::Manager.new(max_workers: 1, batch_size: 1, queue_size: 1, worker_type: :thread)
+      result = Thimble::Thimble.new(source, manager).map_async(cancellation: token) do |value|
+        worker_entered << true
+        worker_release.pop
+        value
+      end
+      Timeout.timeout(1) { worker_entered.pop }
+
+      expect(result.drain('rolling deploy')).to be(true)
+      expect(result).to be_draining
+      source_release << true
+      worker_release << true
+
+      expect(result.to_a).to eq([1])
+      expect(result.wait(timeout: 1)).to equal(result.execution)
+      expect(result).to be_drained
+      expect(result.shutdown_reason).to eq('rolling deploy')
+      expect(result.error).to be_nil
+      expect(manager).not_to be_working
+    end
+
+    it 'drains connected queue stages under one shared token' do
+      token = Thimble::CancellationToken.new
+      entered = Queue.new
+      release = Queue.new
+      first_manager = Thimble::Manager.new(max_workers: 1, batch_size: 1, queue_size: 2, worker_type: :thread)
+      second_manager = Thimble::Manager.new(max_workers: 1, batch_size: 1, queue_size: 2, worker_type: :thread)
+
+      intermediate = Thimble::Thimble.new((1..100).to_a, first_manager).map_async(cancellation: token) do |value|
+        if value == 1
+          entered << true
+          release.pop
+        end
+        value * 2
+      end
+      output = Thimble::Thimble.new(intermediate, second_manager).map_async(cancellation: token) { |value| value + 1 }
+      Timeout.timeout(1) { entered.pop }
+
+      token.drain('pipeline drain')
+      release << true
+      values = Timeout.timeout(3) { output.to_a }
+
+      expect(values).not_to be_empty
+      expect(values).to all(be_odd)
+      expect(intermediate.wait(timeout: 1)).to equal(intermediate.execution)
+      expect(output.wait(timeout: 1)).to equal(output.execution)
+      expect(intermediate).to be_drained
+      expect(output).to be_drained
+      expect(first_manager).not_to be_working
+      expect(second_manager).not_to be_working
+    end
+  end
+end

--- a/spec/retry_policy_spec.rb
+++ b/spec/retry_policy_spec.rb
@@ -1,0 +1,241 @@
+# frozen_string_literal: true
+
+require 'thimble'
+
+RSpec.describe Thimble::RetryPolicy do
+  describe 'configuration and classification' do
+    it 'calculates bounded exponential backoff with deterministic jitter' do
+      random = Class.new do
+        def rand
+          0.5
+        end
+      end.new
+      policy = described_class.new(
+        max_attempts: 5,
+        base_delay: 0.25,
+        max_delay: 1.0,
+        multiplier: 2.0,
+        jitter: 0.4
+      )
+
+      expect(policy.delay_for(1, random: random)).to eq(0.25)
+      expect(policy.delay_for(2, random: random)).to eq(0.5)
+      expect(policy.delay_for(3, random: random)).to eq(1.0)
+      expect(policy.delay_for(4, random: random)).to eq(1.0)
+    end
+
+    it 'applies abort classifiers before retry classifiers' do
+      policy = described_class.new(
+        max_attempts: 3,
+        retry_on: StandardError,
+        abort_on: [ArgumentError, ->(error, _context) { error.message == 'permanent' }]
+      )
+
+      expect(policy.retryable?(IOError.new('temporary'))).to be(true)
+      expect(policy.retryable?(ArgumentError.new('temporary'))).to be(false)
+      expect(policy.retryable?(IOError.new('permanent'))).to be(false)
+      expect(policy.retryable?(Thimble::CancelledError.new)).to be(false)
+    end
+
+    it 'validates bounded retry settings' do
+      expect { described_class.new(max_attempts: 0) }.to raise_error(ArgumentError, /max_attempts/)
+      expect do
+        described_class.new(max_attempts: 2, base_delay: 2, max_delay: 1)
+      end.to raise_error(ArgumentError, /max_delay/)
+      expect { described_class.new(max_attempts: 2, jitter: 2) }.to raise_error(ArgumentError, /jitter/)
+      expect do
+        described_class.new(max_attempts: 2, retry_on: Object.new)
+      end.to raise_error(ArgumentError, /retry_on/)
+    end
+  end
+
+  describe 'supervised retry execution' do
+    it 'retries individual items and supplies attempt context to the block' do
+      attempts = Hash.new(0)
+      contexts = Queue.new
+      manager = Thimble::Manager.new(max_workers: 2, batch_size: 1, queue_size: 2, worker_type: :thread)
+      policy = described_class.new(max_attempts: 3, base_delay: 0)
+
+      result = Thimble::Thimble.new([1, 2], manager).map(retry_policy: policy) do |value, context|
+        contexts << context
+        attempts[value] += 1
+        raise IOError, 'temporary' if attempts[value] == 1
+
+        value * 10
+      end
+
+      expect(result.to_a).to contain_exactly(10, 20)
+      expect(attempts).to eq(1 => 2, 2 => 2)
+      observed = 4.times.map { Timeout.timeout(1) { contexts.pop } }
+      expect(observed.map(&:attempt).sort).to eq([1, 1, 2, 2])
+      expect(observed).to all(be_a(Thimble::AttemptContext))
+      expect(observed).to all(have_attributes(max_attempts: 3, batch_size: 1, worker_type: :thread))
+      expect(observed.map(&:worker_id)).to all(be_a(Integer))
+    end
+
+    it 'retries a whole batch as one operation' do
+      attempts = 0
+      manager = Thimble::Manager.new(max_workers: 1, batch_size: 3, queue_size: 2, worker_type: :thread)
+
+      result = Thimble::Thimble.new((1..3).to_a, manager).map_batches(retry_policy: 2) do |batch, context|
+        attempts += 1
+        raise IOError, 'temporary' if context.first_attempt?
+
+        batch.sum
+      end
+
+      expect(result.to_a).to eq([6])
+      expect(attempts).to eq(2)
+    end
+
+    it 'raises structured failure context after retries are exhausted' do
+      manager = Thimble::Manager.new(max_workers: 1, batch_size: 1, queue_size: 1, worker_type: :thread)
+
+      expect do
+        Thimble::Thimble.new([7], manager).map(retry_policy: 2) do
+          raise IOError, 'service unavailable'
+        end.to_a
+      end.to raise_error(Thimble::WorkFailedError) { |error|
+        expect(error.cause).to be_a(IOError)
+        expect(error.failure).to have_attributes(
+          input: 7,
+          attempt: 2,
+          max_attempts: 2,
+          retryable: true,
+          exhausted: true,
+          classification: :retry_exhausted,
+          batch_size: 1,
+          worker_type: :thread
+        )
+      }
+    end
+
+    it 'routes final failures to a dead-letter sink and continues explicitly' do
+      dead_letters = []
+      manager = Thimble::Manager.new(max_workers: 2, batch_size: 1, queue_size: 2, worker_type: :thread)
+
+      result = Thimble::Thimble.new([1, 2, 3], manager).map(
+        retry_policy: { max_attempts: 2, base_delay: 0 },
+        dead_letter: dead_letters,
+        failure_mode: :continue
+      ) do |value|
+        raise IOError, 'permanent' if value == 2
+
+        value
+      end
+
+      expect(result.to_a).to contain_exactly(1, 3)
+      expect(dead_letters.length).to eq(1)
+      expect(dead_letters.first).to have_attributes(
+        input: 2,
+        attempt: 2,
+        classification: :retry_exhausted
+      )
+      expect(dead_letters.first.error).to be_a(IOError)
+    end
+
+    it 'does not retry errors rejected by the classifier' do
+      dead_letters = []
+      manager = Thimble::Manager.new(max_workers: 1, batch_size: 1, queue_size: 1, worker_type: :thread)
+      policy = described_class.new(max_attempts: 5, retry_on: IOError, abort_on: ArgumentError)
+
+      Thimble::Thimble.new([1], manager).map(
+        retry_policy: policy,
+        dead_letter: dead_letters,
+        failure_mode: :continue
+      ) { raise ArgumentError, 'invalid input' }.to_a
+
+      expect(dead_letters.first).to have_attributes(
+        attempt: 1,
+        retryable: false,
+        exhausted: false,
+        classification: :non_retryable
+      )
+    end
+
+    it 'preserves legacy exception types when retry and dead-letter options are absent' do
+      manager = Thimble::Manager.new(max_workers: 1, batch_size: 1, queue_size: 1, worker_type: :thread)
+
+      expect do
+        Thimble::Thimble.new([1], manager).map(&:missing_method).to_a
+      end.to raise_error(NoMethodError, /missing_method/)
+    end
+
+    it 'does not add attempt context to legacy splat blocks unless retries are enabled' do
+      manager = Thimble::Manager.new(max_workers: 1, batch_size: 1, queue_size: 1, worker_type: :thread)
+
+      legacy = Thimble::Thimble.new([1], manager).map { |*arguments| arguments }.to_a
+      retried = Thimble::Thimble.new([1], manager).map(retry_policy: 1) { |*arguments| arguments }.to_a
+
+      expect(legacy).to eq([[1]])
+      expect(retried.first.length).to eq(2)
+      expect(retried.first.last).to be_a(Thimble::AttemptContext)
+    end
+
+    it 'supervises blocking dead-letter callbacks with the stage deadline' do
+      manager = Thimble::Manager.new(max_workers: 1, batch_size: 1, queue_size: 1, worker_type: :thread)
+      result = Thimble::Thimble.new([1], manager).map_async(
+        timeout: 0.05,
+        retry_policy: 1,
+        dead_letter: ->(_failure) { Queue.new.pop },
+        failure_mode: :continue
+      ) { raise IOError, 'failed' }
+
+      expect { result.to_a }.to raise_error(Thimble::StageTimeoutError)
+      expect(result.wait(timeout: 1)).to equal(result.execution)
+      expect(result).to be_timed_out
+      expect(manager).not_to be_working
+    end
+
+    it 'interrupts retry backoff on immediate cancellation' do
+      token = Thimble::CancellationToken.new
+      attempted = Queue.new
+      policy = described_class.new(max_attempts: 100, base_delay: 10, max_delay: 10)
+      manager = Thimble::Manager.new(max_workers: 1, batch_size: 1, queue_size: 1, worker_type: :thread)
+      result = Thimble::Thimble.new([1], manager).map_async(
+        cancellation: token,
+        retry_policy: policy
+      ) do
+        attempted << true
+        raise IOError, 'temporary'
+      end
+      Timeout.timeout(1) { attempted.pop }
+
+      token.cancel('stop retries')
+
+      expect { result.to_a }.to raise_error(Thimble::CancelledError, /stop retries/)
+      expect(result.wait(timeout: 1)).to equal(result.execution)
+      expect(manager).not_to be_working
+    end
+
+    it 'requires a dead-letter sink before failures may be continued' do
+      manager = Thimble::Manager.new(worker_type: :thread)
+
+      expect do
+        Thimble::Thimble.new([1], manager).map(failure_mode: :continue) { |value| value }
+      end.to raise_error(ArgumentError, /dead_letter/)
+    end
+
+    it 'marshals structured failure context from fork workers' do
+      skip 'fork is not available on this platform' unless Process.respond_to?(:fork)
+
+      dead_letters = []
+      manager = Thimble::Manager.new(max_workers: 1, batch_size: 1, queue_size: 1, worker_type: :fork)
+      input = proc {}
+
+      result = Thimble::Thimble.new([input], manager).map(
+        retry_policy: 1,
+        dead_letter: dead_letters,
+        failure_mode: :continue
+      ) { raise IOError, 'remote failure' }
+
+      expect(result.to_a).to eq([])
+      expect(dead_letters.first).to have_attributes(worker_type: :fork, input_class: 'Proc')
+      expect(dead_letters.first.input).to be_nil
+      expect(dead_letters.first).not_to be_input_available
+      expect(dead_letters.first.input_summary).to include('Proc')
+      expect(dead_letters.first.error).to be_a(IOError)
+      expect(manager).not_to be_working
+    end
+  end
+end

--- a/spec/shutdown_coordinator_spec.rb
+++ b/spec/shutdown_coordinator_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'thimble'
+
+RSpec.describe Thimble::ShutdownCoordinator do
+  it 'requests graceful drain on the first notification and immediate cancellation on the second' do
+    token = Thimble::CancellationToken.new
+    coordinator = described_class.new(token: token, signals: ['TERM'], grace_period: nil)
+
+    expect(coordinator.notify('TERM')).to be(true)
+    expect(token).to be_draining
+    expect(token.reason).to include('SIGTERM')
+
+    expect(coordinator.notify(:term)).to be(true)
+    expect(token).to be_cancelled
+    expect(token.error).to be_a(Thimble::CancelledError)
+  ensure
+    coordinator&.close
+  end
+
+  it 'escalates when registered executions exceed the grace period' do
+    token = Thimble::CancellationToken.new
+    execution = Thimble::Execution.new(name: 'hung stage', token: token).start!
+    coordinator = described_class.new(token: token, signals: ['TERM'], grace_period: 0.03)
+    coordinator.register(execution)
+
+    coordinator.notify('TERM')
+    error = token.wait_for_cancel(timeout: 1)
+
+    expect(error).to be_a(Thimble::ShutdownTimeoutError)
+    expect(error.grace_period).to eq(0.03)
+    execution.fail!(error)
+  ensure
+    coordinator&.close
+  end
+
+  it 'does not escalate after every registered execution finishes draining' do
+    token = Thimble::CancellationToken.new
+    execution = Thimble::Execution.new(name: 'short stage', token: token).start!
+    coordinator = described_class.new(token: token, signals: ['TERM'], grace_period: 0.1)
+    coordinator.register(execution)
+
+    coordinator.notify('TERM')
+    execution.succeed!
+
+    expect(token.wait_for_cancel(timeout: 0.15)).to be_nil
+    expect(execution).to be_drained
+    expect(token).to be_draining
+    expect(token).not_to be_cancelled
+  ensure
+    coordinator&.close
+  end
+
+  it 'routes installed process signals through a self-pipe and restores handlers' do
+    skip 'USR1 is unavailable on this platform' unless Signal.list.key?('USR1')
+
+    token = Thimble::CancellationToken.new
+    coordinator = described_class.new(token: token, signals: ['USR1'], grace_period: nil)
+    coordinator.install
+
+    Process.kill('USR1', Process.pid)
+
+    request = token.wait_for_shutdown(timeout: 1)
+    expect(request).to be_graceful
+    expect(request.reason).to include('SIGUSR1')
+  ensure
+    coordinator&.close
+  end
+
+  it 'validates targets, signals, and grace periods' do
+    expect { described_class.new(signals: []) }.to raise_error(ArgumentError, /at least one/)
+    expect { described_class.new(signals: ['NOT_A_SIGNAL']) }.to raise_error(ArgumentError, /unsupported/)
+    expect { described_class.new(grace_period: 0) }.to raise_error(ArgumentError, /grace_period/)
+
+    coordinator = described_class.new(signals: ['TERM'], grace_period: nil)
+    expect { coordinator.register(Object.new) }.to raise_error(ArgumentError, /Execution/)
+    expect { coordinator.notify('INT') }.to raise_error(ArgumentError, /configured/)
+
+    coordinator.notify('TERM')
+    execution = Thimble::Execution.new(name: 'late', token: coordinator.token)
+    expect { coordinator.register(execution) }.to raise_error(RuntimeError, /after shutdown/)
+  ensure
+    coordinator&.close
+  end
+end


### PR DESCRIPTION
## Why

PR #4 added explicit execution lifecycle, immediate cancellation, and stage/worker deadlines. The remaining supervision roadmap still lacked the operational behavior needed for long-running bounded pipelines:

- graceful shutdown needed to stop ingress without discarding accepted work;
- transient failures needed bounded, classified retries rather than ad hoc loops in user blocks;
- final failures needed enough item/batch/attempt context to diagnose and route them;
- continuing past failed items needed an explicit dead-letter contract;
- process signals needed a safe bridge into normal Ruby execution and deterministic escalation.

This PR completes that supervision layer before moving on to the larger first-class stage and pipeline-builder API.

## What changed

### Graceful drain and escalation

- add graceful and immediate shutdown modes to `CancellationToken`;
- add `draining` and `drained` execution states alongside the existing cancellation states;
- expose `drain`, `shutdown`, `draining?`, `drained?`, and `shutdown_reason` through result queues;
- stop root enumerable ingress at the next cooperative boundary;
- continue draining accepted work through stages whose source is another `ThimbleQueue`;
- allow any graceful request to be escalated later through immediate `cancel`;
- preserve stage and worker deadlines while a pipeline is draining.

### Bounded retry policy

- add `Thimble::RetryPolicy` with total `max_attempts`, exponential backoff, a maximum delay, multiplier, and bounded jitter;
- accept a policy object, integer attempt count, or option hash on every map variant;
- support exception classes and callables in `retry_on` and `abort_on`, with abort classification taking precedence;
- avoid retrying cancellation and common programming/input errors by default;
- make thread-worker backoff immediately interruptible by cancellation;
- include retries and backoff inside existing stage and worker deadlines;
- keep fork retry execution free of mutexes copied from a multithreaded parent.

### Structured attempt and failure context

- add `AttemptContext` for optional second block arguments when retries are enabled;
- add `FailureContext` with payload/error snapshots, attempts, classification, batch metadata, worker identity, and timing;
- add `WorkFailedError`, preserving the original worker exception as Ruby's cause where possible;
- reconstruct non-marshallable remote exceptions as `RemoteWorkerError` while retaining class, message, and backtrace;
- retain exact historical worker exception types when retry/dead-letter options are absent;
- preserve all-or-fail visibility for one dispatched worker batch so async consumers cannot observe a partial batch before a sibling failure aborts it.

### Dead-letter behavior

- accept callable, queue, array, and `push`/`<<` sinks;
- require a sink when `failure_mode: :continue` is selected so failed work cannot disappear silently;
- deliver one final `FailureContext` after classification or retry exhaustion;
- notify the sink and then fail by default, or explicitly continue successful work with `:continue`;
- supervise blocking callback sinks with stage cancellation and deadlines;
- report sink failures through `DeadLetterError` with the original failure context.

### Signal-friendly shutdown

- add `ShutdownCoordinator` using a self-pipe so signal traps perform only a nonblocking write;
- request graceful drain on the first configured signal;
- escalate on a repeated signal or expired grace period;
- register result queues or executions that must finish during the grace window;
- restore previous process signal handlers on close;
- require handler installation/restoration on the main Ruby thread.

### Documentation and roadmap

- document retries, classifiers, failure context, dead letters, graceful drain, and process-signal coordination;
- fix the previous README formatting defects around queue and cancellation examples;
- move complete supervision into the current foundation;
- make first-class stages and pipeline composition the next roadmap milestone.

## Public API examples

```ruby
policy = Thimble::RetryPolicy.new(
  max_attempts: 4,
  base_delay: 0.1,
  max_delay: 2,
  jitter: 0.2,
  retry_on: [IOError, Errno::ECONNRESET],
  abort_on: [ArgumentError]
)

result = Thimble::Thimble.new(events, manager).map_async(
  retry_policy: policy,
  dead_letter: dead_letters,
  failure_mode: :continue,
  cancellation: token,
  timeout: 30,
  worker_timeout: 5
) do |event, attempt|
  client.deliver(event)
end
```

```ruby
shutdown = Thimble::ShutdownCoordinator.new(
  token: token,
  signals: %w[INT TERM],
  grace_period: 15
)
shutdown.register(result).install
```

## Compatibility notes

- existing calls without retry, dead-letter, or failure-mode options keep their original exception types and block argument behavior;
- `max_attempts` includes the first attempt;
- supplying `retry_policy` enables the optional `AttemptContext` second block argument;
- graceful drain is cooperative for root enumerators blocked inside their own code; a deadline or coordinator grace period provides forced escalation;
- graceful requests allow retries for already accepted work, while immediate cancellation interrupts thread retry backoff;
- fork workers cannot observe post-fork token mutations and remain supervised from the parent process;
- `failure_mode: :continue` is intentionally unavailable without a dead-letter sink.

## Validation

- syntax checked every candidate library and spec file on Ruby 3.3.8;
- ran a compatibility harness covering thread/fork mapping, retry success/exhaustion, attempt context, symbol-proc compatibility, dead-letter continuation, classification, structured causes, legacy exceptions, graceful drain, immediate cancellation, batch retry, fork snapshots, and signal escalation;
- stress-tested 100 thread retry maps, 50 dead-letter maps, 50 controlled drains, 25 connected shared-token drains, 25 cancellation-during-backoff cases, 20 fork retry maps, and shared-manager capacity races;
- exercised 1,000 graceful/immediate request races;
- verified no worker registrations, callback delivery threads, or child processes remained after timeout/cancellation stress cases;
- added regression coverage preventing partial asynchronous output from a failed dispatched worker batch;
- GitHub Actions runs the complete RSpec suite and gem build on Ruby 3.3, 3.4, and 4.0.